### PR TITLE
feat: force download of crx files

### DIFF
--- a/__tests__/scripts.mock.html
+++ b/__tests__/scripts.mock.html
@@ -1,6 +1,7 @@
 <div class="anchors">
     <a href="https://www.hlx.live/my-content">My awesome page</a>
     <a href="https://www.adobe.com">Adobe</a>
+    <a id="crx" href="/tools/sidekick/extension.crx">Download Chrome Extension</a>
     <a href="https://www.hlx.live/img/icon-content.svg">https://www.hlx.live/img/icon-content.svg</a>
     <a href="https://www.hlx.live/my-awesome-link">https://www.hlx.live/img/icon-content.svg</a>
 </div>

--- a/__tests__/scripts.test.js
+++ b/__tests__/scripts.test.js
@@ -50,6 +50,11 @@ describe('Anchors', () => {
     const currentDomain = getCurrentDomain(location);
     expect(currentDomain).to.equal('http://localhost');
   });
+
+  it('crx link has download attribute', () => {
+    const crxAnchor = document.getElementById('crx');
+    expect(crxAnchor.download).to.equal('extension.crx');
+  });
 });
 
 describe('Block variations', () => {

--- a/scripts.js
+++ b/scripts.js
@@ -91,12 +91,22 @@ export function setSVG(anchor) {
   }
 }
 
+export function forceDownload(anchor) {
+  const { href } = anchor;
+  const filename = href.split('/').pop();
+  const ext = filename.split('.')[1];
+  if (ext && ['crx'].includes(ext)) {
+    anchor.setAttribute('download', filename);
+  }
+}
+
 export function decorateAnchors(element) {
   const anchors = element.getElementsByTagName('a');
   const currentDomain = getCurrentDomain();
   return Array.from(anchors).map((anchor) => {
     setDomain(anchor, currentDomain);
     setSVG(anchor);
+    forceDownload(anchor);
     return anchor;
   });
 }


### PR DESCRIPTION
Chrome's attempt to open & install the `.crx` file directly will fail with a `CRX_REQUIRED_PROOF_MISSING` error. Users need to download the file and then drag it into their Extension Manager (`chrome://extensions`).