### PR TITLE
chore: event based container display

### DIFF
--- a/blocks/sidekick-generator/sidekick-generator.js
+++ b/blocks/sidekick-generator/sidekick-generator.js
@@ -82,7 +82,6 @@ function run(evt) {
   bm.onclick = help;
   bm.textContent = title;
   bm.setAttribute('title', title);
-  document.getElementById('sidekick-generator-bookmarklet').parentElement.classList.remove('hidden');
 
   window.dispatchEvent(new CustomEvent('sidekickGeneratorReady'));
 }
@@ -112,7 +111,7 @@ function init() {
     document.getElementById('sidekick-generator-bookmarklet').append(createTag('p', null, backLink));
   }
   if (autorun) {
-    document.getElementById('form-container').classList.add('hidden');
+    document.getElementById('form-container').parentElement.classList.add('hidden');
     run();
   }
 }
@@ -188,6 +187,11 @@ export default async function decorate(el) {
     extensionDeleteContainer.querySelector('a').removeAttribute('href');
     extensionDeleteContainer.parentElement.classList.add('hidden');
   }
+
+  window.addEventListener('sidekickGeneratorReady', () => {
+    // show bookmarklet container (default)
+    bookmarkletContainer.parentElement.classList.remove('hidden');
+  });
 
   init();
 }

--- a/tests/blocks/sidekick-generator/sidekick-generator.test.js
+++ b/tests/blocks/sidekick-generator/sidekick-generator.test.js
@@ -49,7 +49,7 @@ describe('Sidekick Generator', () => {
     const generator = document.querySelector('.sidekick-generator');
     await decorate(generator);
     const formContainer = generator.querySelector('#form-container');
-    expect(formContainer.classList.contains('hidden')).to.be.true;
+    expect(formContainer.parentElement.classList.contains('hidden')).to.be.true;
     const bookmark = generator.querySelector('#bookmark');
     expect(bookmark).to.exist;
     expect(bookmark.textContent).to.equal('Foo Sidekick');


### PR DESCRIPTION
Fix #72 

- use `sidekickGeneratorReady` event (fired by the block) to show bookmarklet container


https://issue-72--helix-website--adobe.hlx3.page/