### PR TITLE
fix: reduce sidekick border radius to 4px

### DIFF
--- a/tools/sidekick/app.css
+++ b/tools/sidekick/app.css
@@ -344,7 +344,7 @@
 .hlx-sk-overlay .modal {
   font-family: var(--hlx-sk-font-family);
   font-size: var(--hlx-sk-modal-font-size);
-  border-radius: 32px;
+  border-radius: 4px;
   padding: 12px 32px;
   max-width: 60vw;
   background-color: var(--hlx-sk-bg);


### PR DESCRIPTION
nit: the border radius is a little aggressive for sidekick modals. Setting to 4px which is inline with spectrum. 