### PR TITLE
chore: scroll to hash not always working

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -624,7 +624,11 @@ async function loadLazy(doc) {
 
   const { hash } = window.location;
   const element = hash ? main.querySelector(hash) : false;
-  if (hash && element) element.scrollIntoView();
+  if (hash && element) {
+    setTimeout(() => {
+      element.scrollIntoView();
+    }, 500);
+  }
 
   decorateBlock(header);
   loadBlock(header);


### PR DESCRIPTION
Added a little delay (used successfully in CCX as well) to ensure the page is always scrolling to the hash ID.