### PR TITLE
feat(sidekick): config json schema

### DIFF
--- a/tools/sidekick/config.schema.json
+++ b/tools/sidekick/config.schema.json
@@ -101,15 +101,12 @@
           "description": "The URL to open when the button is clicked"
         }
       },
-      "allOf": [
-        {
-          "anyOf": [
-            { "required": [ "url" ] },
-            { "required": [ "event" ] },
-            { "required": [ "is_container" ] }
-          ]
-        }
-      ],
+      "anyOf": [
+          { "required": [ "url" ] },
+          { "required": [ "event" ] },
+          { "required": [ "is_container" ] }
+        ]
+      },
       "additionalProperties": false
     }
   }

--- a/tools/sidekick/config.schema.json
+++ b/tools/sidekick/config.schema.json
@@ -1,0 +1,116 @@
+{
+  "$id": "https://ns.adobe.com/helix/sidekick/config",
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "description": "Helix Sidekick configuration",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project to display in the Helix Sidekick"
+    },
+    "host": {
+      "type": "string",
+      "format": "hostname",
+      "description": "The host name of the production website"
+    },
+    "container": {
+      "type": "string",
+      "description": "The ID of the dropdown container to add this plugin to"
+    },
+    "pushDown": {
+      "type": "boolean",
+      "description": "Have Helix Sidekick push down page content instead of overlaying it"
+    },
+    "pushDownSelector": {
+      "type": "string",
+      "description": "The query selector for absolute elements to also push down"
+    },
+    "plugins": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/plugin" }
+    }
+   },
+   "additionalProperties": false,
+   "$defs": {
+    "plugin": {
+      "type": "object",
+      "properties": {
+        "container": {
+          "type": "string",
+          "description": "The ID of the container to add this plugin to"
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["any", "edit", "preview", "live", "prod"]
+          },
+          "description": "The environments to display this plugin in (default: any)"
+        },
+        "event": {
+          "type": "string",
+          "description": "The name of a custom event to fire when the button is clicked"
+        },
+        "exclude_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Exclude the plugin from these paths (glob patterns supported)"
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique plugin ID"
+        },
+        "include_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Include the plugin on these paths (glob patterns supported)"
+        },
+        "is_container": {
+          "type": "boolean",
+          "description": "Turns the plugin into a container for other plugins"
+        },
+        "title": {
+          "type": "string",
+          "description": "The button text"
+        },
+        "title_i18n": {
+          "type": "object",
+          "description": "The button text in other supported languages",
+          "properties": {
+            "de": {
+              "type": "string",
+              "description": "German"
+            },
+            "fr": {
+              "type": "string",
+              "description": "French"
+            }
+          },
+          "anyOf": [
+            { "required": [ "de" ] },
+            { "required": [ "fr" ] }
+          ],
+          "additionalProperties": false
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL to open when the button is clicked"
+        }
+      },
+      "allOf": [
+        {
+          "anyOf": [
+            { "required": [ "url" ] },
+            { "required": [ "event" ] },
+            { "required": [ "is_container" ] }
+          ]
+        }
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/tools/sidekick/config.schema.json
+++ b/tools/sidekick/config.schema.json
@@ -102,11 +102,10 @@
         }
       },
       "anyOf": [
-          { "required": [ "url" ] },
-          { "required": [ "event" ] },
-          { "required": [ "is_container" ] }
-        ]
-      },
+        { "required": [ "url" ] },
+        { "required": [ "event" ] },
+        { "required": [ "is_container" ] }
+      ],
       "additionalProperties": false
     }
   }

--- a/tools/sidekick/config.schema.json
+++ b/tools/sidekick/config.schema.json
@@ -1,6 +1,86 @@
 {
   "$id": "https://ns.adobe.com/helix/sidekick/config",
   "$schema": "https://json-schema.org/draft-07/schema#",
+  "$defs": {
+    "plugin": {
+      "type": "object",
+      "properties": {
+        "container": {
+          "type": "string",
+          "description": "The ID of the container to add this plugin to"
+        },
+        "environments": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["any", "edit", "preview", "live", "prod"]
+          },
+          "description": "The environments to display this plugin in",
+          "default": "any"
+        },
+        "event": {
+          "type": "string",
+          "description": "The name of a custom event to fire when the button is clicked"
+        },
+        "exclude_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Exclude the plugin from these paths",
+          "examples": [
+            "/foo/bar",
+            "/foo/**"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique plugin ID"
+        },
+        "include_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Include the plugin on these paths (overrides exclude_paths)",
+          "examples": [
+            "/foo/bar",
+            "/foo/bar/**"
+          ]
+        },
+        "is_container": {
+          "type": "boolean",
+          "description": "Turns the plugin into a container for other plugins"
+        },
+        "title": {
+          "type": "string",
+          "description": "The button text"
+        },
+        "title_i18n": {
+          "type": "object",
+          "description": "The button text in other supported languages",
+          "patternProperties": {
+            "^[a-z]{2}(-[A-Z]{2})?$": {
+              "type": "string",
+              "description": "ISO language code (`en` or `en-US`) with translated button text"
+            }
+          },
+          "minProperties": 1,
+          "additionalProperties": false
+        },
+        "url": {
+          "type": "string",
+          "description": "The URL to open when the button is clicked"
+        }
+      },
+      "anyOf": [
+        { "required": [ "url" ] },
+        { "required": [ "event" ] },
+        { "required": [ "is_container" ] }
+      ],
+      "additionalProperties": false
+    }
+  },
   "description": "Helix Sidekick configuration",
   "type": "object",
   "properties": {
@@ -10,7 +90,7 @@
     },
     "host": {
       "type": "string",
-      "format": "hostname",
+      "format": "idn-hostname",
       "description": "The host name of the production website"
     },
     "container": {
@@ -30,83 +110,5 @@
       "items": { "$ref": "#/$defs/plugin" }
     }
    },
-   "additionalProperties": false,
-   "$defs": {
-    "plugin": {
-      "type": "object",
-      "properties": {
-        "container": {
-          "type": "string",
-          "description": "The ID of the container to add this plugin to"
-        },
-        "environments": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": ["any", "edit", "preview", "live", "prod"]
-          },
-          "description": "The environments to display this plugin in (default: any)"
-        },
-        "event": {
-          "type": "string",
-          "description": "The name of a custom event to fire when the button is clicked"
-        },
-        "exclude_paths": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Exclude the plugin from these paths (glob patterns supported)"
-        },
-        "id": {
-          "type": "string",
-          "description": "The unique plugin ID"
-        },
-        "include_paths": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Include the plugin on these paths (glob patterns supported)"
-        },
-        "is_container": {
-          "type": "boolean",
-          "description": "Turns the plugin into a container for other plugins"
-        },
-        "title": {
-          "type": "string",
-          "description": "The button text"
-        },
-        "title_i18n": {
-          "type": "object",
-          "description": "The button text in other supported languages",
-          "properties": {
-            "de": {
-              "type": "string",
-              "description": "German"
-            },
-            "fr": {
-              "type": "string",
-              "description": "French"
-            }
-          },
-          "anyOf": [
-            { "required": [ "de" ] },
-            { "required": [ "fr" ] }
-          ],
-          "additionalProperties": false
-        },
-        "url": {
-          "type": "string",
-          "description": "The URL to open when the button is clicked"
-        }
-      },
-      "anyOf": [
-        { "required": [ "url" ] },
-        { "required": [ "event" ] },
-        { "required": [ "is_container" ] }
-      ],
-      "additionalProperties": false
-    }
-  }
+   "additionalProperties": false
 }


### PR DESCRIPTION
With Helix Sidekick extension manifest v3, we will switch to a JSON config. This is the schema that defines the supported properties.

@dylandepass @trieloff: this is my first attempt at defining a JSON schema, so I'd appreciate your feedback!

See:
- https://github.com/adobe/helix-sidekick-extension/issues/103
- https://github.com/adobe/helix-sidekick-extension/blob/mv3/docs/API.md#plugin--object