### PR TITLE
feat: video test with MockIntersectionObserver

### DIFF
--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -12,6 +12,7 @@ function decorateVideoBlock($block, videoURL) {
 }
 
 export default function decorate($block) {
+  $block.classList.remove('video');
   const $a = $block.querySelector('a');
   const videoURL = $a.href;
   const observer = new IntersectionObserver((entries) => {

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -12,7 +12,6 @@ function decorateVideoBlock($block, videoURL) {
 }
 
 export default function decorate($block) {
-  $block.classList.remove('video');
   const $a = $block.querySelector('a');
   const videoURL = $a.href;
   const observer = new IntersectionObserver((entries) => {

--- a/tests/blocks/video/video.test.js
+++ b/tests/blocks/video/video.test.js
@@ -21,6 +21,8 @@ describe('Video', () => {
   it('has a video', async () => {
     const block = document.querySelector('.video');
     await decorate(block);
+
+    // trigger the intersection observer
     intersect();
 
     // must contain a video tag

--- a/tests/blocks/video/video.test.js
+++ b/tests/blocks/video/video.test.js
@@ -1,17 +1,33 @@
 /* eslint-disable no-unused-expressions */
-/* global describe it */
+/* global describe it beforeEach, afterEach */
 
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import decorate from '../../../blocks/video/video.js';
+import { setupIntersectionObserverMock, restoreDefaultIntersectionObserver, intersect } from '../../utils.js';
 
 const mock = await readFile({ path: './video.mock.html' });
 document.body.innerHTML = mock;
 
 describe('Video', () => {
-  it('has a video', () => {
-    const video = document.querySelector('.video');
-    decorate(video);
+  beforeEach(() => {
+    setupIntersectionObserverMock();
+  });
+
+  afterEach(() => {
+    restoreDefaultIntersectionObserver();
+  });
+
+  it('has a video', async () => {
+    const block = document.querySelector('.video');
+    await decorate(block);
+    intersect();
+
+    // must contain a video tag
+    const video = document.querySelector('video');
     expect(video).to.exist;
+    const source = video.querySelector('source');
+    expect(source).to.exist;
+    expect(source.src).to.eql('http://localhost:2000/media_1d6e3d8e0e465fb2c43cdcb4c6ba8123693c86117.mp4');
   });
 });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,49 @@
+const defaultIntersectionObserver = IntersectionObserver;
+let instances = [];
+
+const setupIntersectionObserverMock = () => {
+  class MockIntersectionObserver {
+    entries = [];
+
+    constructor(callback) {
+      this.callback = callback;
+      instances.push(this);
+    }
+
+    observe(target) {
+      this.entries.push(target);
+    }
+
+    intersect() {
+      this.callback(this.entries.map((e) => ({ isIntersecting: true, target: e })));
+    }
+  }
+
+  Object.defineProperty(
+    window,
+    'IntersectionObserver',
+    {
+      writable: true,
+      configurable: true,
+      value: MockIntersectionObserver,
+    },
+  );
+};
+
+const intersect = () => {
+  instances.forEach((instance) => instance.intersect());
+};
+
+const restoreDefaultIntersectionObserver = () => {
+  Object.defineProperty(
+    window,
+    'IntersectionObserver',
+    {
+      writable: true,
+      configurable: true,
+      value: defaultIntersectionObserver,
+    },
+  );
+  instances = [];
+};
+export { setupIntersectionObserverMock, restoreDefaultIntersectionObserver, intersect };


### PR DESCRIPTION
Example code with a MockIntersectionObserver to control the intersections and call before tests can be run...

Note that is the not the perfection solution. A better approach would be to unit test the `decorateVideoBlock`. But for that, you need to export the function, at least in the testing env (which would be doable with the build tools that we do not want to use).