### PR TITLE
Integrate Slack Chat into Sidekick

### DIFF
--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -10,20 +10,22 @@ window.hlx.initSidekick({
         text: 'Chat',
         action: (_, sk) => {
           const { config } = sk;
-          window.open(`https://${config.innerHost}/tools/tagger/index.html`, 'hlx-sidekick-chat');
+          SignalZen.show();
         },
       },
     },
   ]
 });
 
-var _sz = _sz || {};
+var _sz = _sz || {
+  invisible: true
+};
 _sz.appId = "8fa40ef3",
   function () {
     var e = document.createElement("script");
-    e.src = "https://cdn.signalzen.com/signalzen.js",
-      e.setAttribute("async", "true"),
-      document.documentElement.firstChild.appendChild(e);
+    e.src = "https://cdn.signalzen.com/signalzen.js";
+    e.setAttribute("async", "true");
+    document.documentElement.firstChild.appendChild(e);
     var t = setInterval(function () {
       "undefined" != typeof SignalZen && (clearInterval(t), new SignalZen(_sz).load());
     }, 10);

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -3,5 +3,28 @@ window.hlx.initSidekick({
   hlx3: true,
   host: 'www.hlx.live',
   pushDownSelector: 'header',
+  plugins: [
+    {
+      id: 'chat',
+      button: {
+        text: 'Chat',
+        action: (_, sk) => {
+          const { config } = sk;
+          window.open(`https://${config.innerHost}/tools/tagger/index.html`, 'hlx-sidekick-chat');
+        },
+      },
+    },
+  ]
 });
-console.log('sk init');
+
+var _sz = _sz || {};
+_sz.appId = "8fa40ef3",
+  function () {
+    var e = document.createElement("script");
+    e.src = "https://cdn.signalzen.com/signalzen.js",
+      e.setAttribute("async", "true"),
+      document.documentElement.firstChild.appendChild(e);
+    var t = setInterval(function () {
+      "undefined" != typeof SignalZen && (clearInterval(t), new SignalZen(_sz).load());
+    }, 10);
+  }();

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -4,3 +4,4 @@ window.hlx.initSidekick({
   host: 'www.hlx.live',
   pushDownSelector: 'header',
 });
+console.log('sk init');

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -19,7 +19,11 @@ window.hlx.initSidekick({
 });
 
 var _sz = _sz || {
-  invisible: true
+  invisible: true,
+  userData: {
+    name: hlx.sidekick.status.profile.name,
+    email: hlx.sidekick.status.profile.email,
+  }
 };
 _sz.appId = "8fa40ef3",
   function () {

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -11,7 +11,7 @@ window.hlx.initSidekick({
         action: (_, sk) => {
           const { config } = sk;
           console.log('foo');
-          SignalZen.show();
+          SignalZen.expand();
         },
       },
     },

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -10,7 +10,7 @@ window.hlx.initSidekick({
         text: 'Chat',
         action: (_, sk) => {
           const { config } = sk;
-          console.log('foo');
+          SignalZen.show();
           SignalZen.expand();
         },
       },

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -10,6 +10,7 @@ window.hlx.initSidekick({
         text: 'Chat',
         action: (_, sk) => {
           const { config } = sk;
+          console.log('foo');
           SignalZen.show();
         },
       },

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -9,6 +9,13 @@ window.hlx.initSidekick({
       button: {
         text: 'Chat',
         action: (_, sk) => {
+          window._sz = {
+            invisible: true,
+            userData: {
+              name: hlx.sidekick.status.profile.name,
+              email: hlx.sidekick.status.profile.email,
+            }
+          };
           const { config } = sk;
           SignalZen.show();
           SignalZen.expand();
@@ -20,10 +27,6 @@ window.hlx.initSidekick({
 
 var _sz = _sz || {
   invisible: true,
-  userData: {
-    name: hlx.sidekick.status.profile.name,
-    email: hlx.sidekick.status.profile.email,
-  }
 };
 _sz.appId = "8fa40ef3",
   function () {


### PR DESCRIPTION
- chore(sidekick): add some logging
- feat(sidekick): add chat plugin
- feat(sidekick): hide widget by default
- chore(sidekick): log clicks
- feat(sidekick): show chat
- feat(sidekick): show and expand chat
- feat(sidekick): share profile data
- feat(sidekick): share profile data

This is a rough POC that integrates a "Chat" button into the
sidekick. Under the hoods, SignalZen renders the chat window
and handles the Slack conversations and all the "Chat" button
does is to show the chat window.

This is meant to be seen as a POC, not a WIP and will need some
guidance from @rofe. There are a number of possible enhancements:
- delay loading the SignalZen script until the button is clicked
- share the authenticated user's info with SZ
- properly hide the chat button when SK gets hidden
- deal with the public/private Slack instances we use

demo here: https://cq-dev.slack.com/archives/C9KD0TT6G/p1658230769980729
