### PR TITLE
fix(scripts): avoid race condition for `scrollIntoView`

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -510,12 +510,12 @@ export function decorateButtons(block = document) {
           $up.classList.add('button-container');
         }
         if ($up.childNodes.length === 1 && $up.tagName === 'STRONG'
-            && $twoup.childNodes.length === 1 && $twoup.tagName === 'P') {
+          && $twoup.childNodes.length === 1 && $twoup.tagName === 'P') {
           $a.className = 'button accent';
           $twoup.classList.add('button-container');
         }
         if ($up.childNodes.length === 1 && $up.tagName === 'EM'
-            && $twoup.childNodes.length === 1 && $twoup.tagName === 'P') {
+          && $twoup.childNodes.length === 1 && $twoup.tagName === 'P') {
           $a.className = 'button accent light';
           $twoup.classList.add('button-container');
         }
@@ -623,10 +623,13 @@ async function loadLazy(doc) {
   loadBlocks(main);
 
   const { hash } = window.location;
-  const element = hash ? main.querySelector(hash) : false;
-  if (hash && element) {
+
+  if (hash) {
     setTimeout(() => {
-      element.scrollIntoView();
+      const element = hash ? main.querySelector(hash) : false;
+      if (element) {
+        element.scrollIntoView();
+      }
     }, 500);
   }
 


### PR DESCRIPTION
the previous fix would not account for delayed loading of fragments
such as the FAQ block, causing the condition not being met and
the timout never being set.

fixes #111 alternative to #124

Before: https://main--helix-website--adobe.hlx.page/docs/faq#q33
After: https://fragment-identifier-scroll--helix-website--adobe.hlx.page/docs/faq#q33