### PR TITLE
fix(form): checkbox styling

### DIFF
--- a/blocks/form/checkbox-checked.svg
+++ b/blocks/form/checkbox-checked.svg
@@ -1,4 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="#5CFF85" viewBox="0 0 24 24">
-        <path d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z">
-        </path>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.5.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FA0F01;}
+</style>
+<path class="st0" d="M19,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V5C21,3.9,20.1,3,19,3z M10,17l-5-5l1.4-1.4
+	l3.6,3.6l7.6-7.6L19,8L10,17z"/>
 </svg>

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -70,7 +70,6 @@ main .form .form-checkbox-wrapper input[type='checkbox'] {
 
 main .form .form-checkbox-wrapper input[type='checkbox'] + label::before {
   float: left;
-  margin-top: 5px;
   margin-right: 5px;
   height: 30px;
   width: 30px;

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -70,6 +70,7 @@ main .form .form-checkbox-wrapper input[type='checkbox'] {
 
 main .form .form-checkbox-wrapper input[type='checkbox'] + label::before {
   float: left;
+  margin-top: 2px;
   margin-right: 5px;
   height: 30px;
   width: 30px;
@@ -86,6 +87,7 @@ main .form .form-checkbox-wrapper input[type='checkbox']:checked +label::before 
 
 main .form .form-checkbox-wrapper label {
   font-size: var(--type-body-m-size);
+  line-height: var(--type-body-m-lh);
   font-weight: normal;
   text-transform: none;
   display: block;

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -130,7 +130,7 @@ async function createForm(formURL) {
     fd.Type = fd.Type || 'text';
     const fieldWrapper = document.createElement('div');
     const style = fd.Style ? ` form-${fd.Style}` : '';
-    const fieldId = `form-${fd.Field}-wrapper${style}`;
+    const fieldId = `form-${fd.Type}-wrapper${style}`;
     fieldWrapper.className = fieldId;
     fieldWrapper.classList.add('field-wrapper');
     switch (fd.Type) {


### PR DESCRIPTION
There is `.form-checkbox-wrapper` styling, but the class is only applied to fields labeled `checkbox`. This change applies the class name based on the type instead of label.

Before: https://main--helix-website--adobe.hlx.page/vip/customer-intake
After: https://form-tweaks--helix-website--adobe.hlx.page/vip/customer-intake