### PR TITLE
feat: copy anchor links on headings

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -547,6 +547,24 @@ export function decorateButtons(block = document) {
   });
 }
 
+export function decorateHeadings(main) {
+  main.querySelectorAll('h2, h3, h4, h5, h6').forEach((h) => {
+    const link = document.createElement('a');
+    link.setAttribute('href', `#${h.id}`);
+    link.setAttribute('title', `Copy link to "${h.textContent}" to clipboard`);
+    link.classList.add('anchor-link');
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      navigator.clipboard.writeText(link.href);
+      e.target.classList.add('anchor-link-copied');
+      setTimeout(() => e.target.classList.remove('anchor-link-copied'), 1000);
+    });
+    link.innerHTML = h.innerHTML;
+    h.innerHTML = '';
+    h.append(link);
+  });
+}
+
 export function loadScript(url, callback, type) {
   const script = document.createElement('script');
   script.onload = callback;
@@ -619,6 +637,7 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateButtons(main);
+  decorateHeadings(main);
   decorateBlocks(main);
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -588,6 +588,29 @@ main .section.light {
     background: #eee;
 }
 
+main a.anchor-link:any-link {
+  position: relative;
+  text-decoration: none;
+  color: currentcolor;
+  transition: color 0.2s;
+}
+
+main a.anchor-link:any-link::before {
+  content: "#";
+  position: absolute;
+  left: -1.5rem;
+  opacity: 0.2;
+}
+
+main a.anchor-link:hover::before {
+  text-decoration: none;
+  opacity: 1;
+}
+
+main a.anchor-link.anchor-link-copied {
+  color: green;
+}
+
 /* Above the fold */
 
 main .section[data-section-status='loading'], main .section[data-section-status='initialized'] {


### PR DESCRIPTION
Clicking headings should copy anchor link to clipboard (or right-click > copy link address)

https://main--helix-website--adobe.hlx.page/docs/sidekick
vs
https://anchor-links--helix-website--adobe.hlx.page/docs/sidekick