### PR TITLE
feat: add sidekick library block

### DIFF
--- a/blocks/sidekick-library/sidekick-library.css
+++ b/blocks/sidekick-library/sidekick-library.css
@@ -1,3 +1,4 @@
-main .section.sidekick-library-container {
+body.docs-template main .section:has(.sidekick-library-wrapper) {
     padding: 0;
+    max-width: 100%;
 }

--- a/blocks/sidekick-library/sidekick-library.css
+++ b/blocks/sidekick-library/sidekick-library.css
@@ -1,0 +1,3 @@
+main .section.sidekick-library-container {
+    padding: 0;
+}

--- a/blocks/sidekick-library/sidekick-library.js
+++ b/blocks/sidekick-library/sidekick-library.js
@@ -1,0 +1,6 @@
+import '../../tools/sidekick/library/index.js';
+
+export default function decorate(block) {
+  const library = document.createElement('sidekick-library');
+  block.replaceChildren(library);
+}

--- a/head.html
+++ b/head.html
@@ -1,5 +1,5 @@
 <!-- v7 -->
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+<script src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -676,11 +676,17 @@ async function loadLazy(doc) {
     }, 500);
   }
 
-  decorateBlock(header);
-  loadBlock(header);
-
   loadCSS('/fonts/fonts.css');
   addFavIcon(`${window.hlx.codeBasePath}/img/icon-helix.svg`);
+
+  if (getMetadata('supressframe')) {
+    doc.querySelector('header').remove();
+    doc.querySelector('footer').remove();
+    return;
+  }
+
+  decorateBlock(header);
+  loadBlock(header);
 
   decorateBlock(footer);
   loadBlock(footer);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The PR adds the sidekick library block. Customers who use the sidekick library will load the hosted library using this block.

[Demo](https://sidekick-library--helix-website--adobe.hlx.page/tools/sidekick/library?base=https://main--helix-test-content-onedrive--adobe.hlx.page/block-library-tests/library-single-sheet.json)

Couple notes.
* The `crossorigin="use-credentials"` attribute was removed from the script tag importing `scripts.js`. This is required so that the sidekick library can receive responses from requests that return `*` in the `access-control-allow-origin` header. Based on [this thread](https://cq-dev.slack.com/archives/C9KD0TT6G/p1666685656854529) I believe that this is a change that just haven't come across yet from boilerplate. 
* When the sidekick library page renders, it cannot also render the header or footer. To fix this I added some bulk metadata on the `/tools/sidekick/library` path that will add a `supressFrame` metadata tag to the page. `scripts.js` was updated to not load the header or footer if this metadata exists.
 
Test URLS
Before:  https://main--helix-website--adobe.hlx.live/
After: https://sidekick-library--helix-website--adobe.hlx.live/
