### PR TITLE
change submit button selector to get the right button

### DIFF
--- a/blocks/sidekick-generator/sidekick-generator.js
+++ b/blocks/sidekick-generator/sidekick-generator.js
@@ -72,7 +72,6 @@ function run(evt) {
     };
   }
 
-
   // pass token
   if (token) {
     config.token = token;

--- a/blocks/sidekick-generator/sidekick-generator.js
+++ b/blocks/sidekick-generator/sidekick-generator.js
@@ -45,16 +45,33 @@ function run(evt) {
   window.history.pushState({ giturl, project }, null, url.href);
 
   // assemble bookmarklet config
-  const segs = new URL(giturl).pathname.substring(1).split('/');
-  const owner = segs[0];
-  const repo = segs[1];
-  const ref = segs[3] || 'main';
+  const giturlAsUrl = new URL(giturl);
+  let config;
+  if (giturlAsUrl.hostname.endsWith('hlx.page') || giturlAsUrl.hostname.endsWith('hlx.live')) {
+    const segs = giturlAsUrl.hostname.split('.')[0].split('--');
+    const owner = segs[2];
+    const repo = segs[1];
+    const ref = segs[0] || 'main';
 
-  const config = {
-    owner,
-    repo,
-    ref,
-  };
+    config = {
+      owner,
+      repo,
+      ref,
+    };
+  } else {
+    // assume gh.com
+    const segs = giturlAsUrl.pathname.substring(1).split('/');
+    const owner = segs[0];
+    const repo = segs[1];
+    const ref = segs[3] || 'main';
+
+    config = {
+      owner,
+      repo,
+      ref,
+    };
+  }
+
 
   // pass token
   if (token) {
@@ -124,7 +141,7 @@ function init() {
 export default async function decorate(el) {
   const formContainer = el.querySelector(':scope > div:first-of-type > div');
 
-  const submitLink = formContainer.querySelector(':scope a');
+  const submitLink = formContainer.querySelector(':scope p > a');
   const button = createTag('button', { id: 'generator' }, submitLink ? submitLink.textContent : 'Go');
   button.onclick = run;
   if (submitLink) {

--- a/blocks/sidekick-generator/sidekick-generator.js
+++ b/blocks/sidekick-generator/sidekick-generator.js
@@ -37,40 +37,37 @@ function run(evt) {
     return;
   }
 
-  // update URL
-  const url = new URL(window.location.href);
-  const usp = url.searchParams;
-  Object.keys(formData).forEach((name) => usp.set(name, formData[name]));
-  url.search = usp.toString();
-  window.history.pushState({ giturl, project }, null, url.href);
-
-  // assemble bookmarklet config
+  let finalGitUrl = giturl;
   const giturlAsUrl = new URL(giturl);
-  let config;
   if (giturlAsUrl.hostname.endsWith('hlx.page') || giturlAsUrl.hostname.endsWith('hlx.live')) {
     const segs = giturlAsUrl.hostname.split('.')[0].split('--');
     const owner = segs[2];
     const repo = segs[1];
     const ref = segs[0] || 'main';
 
-    config = {
-      owner,
-      repo,
-      ref,
-    };
-  } else {
-    // assume gh.com
-    const segs = giturlAsUrl.pathname.substring(1).split('/');
-    const owner = segs[0];
-    const repo = segs[1];
-    const ref = segs[3] || 'main';
-
-    config = {
-      owner,
-      repo,
-      ref,
-    };
+    finalGitUrl = `https://github.com/${owner}/${repo}/tree/${ref}`;
   }
+
+  // update URL
+  const url = new URL(window.location.href);
+  const usp = url.searchParams;
+  Object.keys(formData).forEach((name) => usp.set(name, formData[name]));
+  // override giturl in case original was hlx url
+  usp.set('giturl', finalGitUrl);
+  url.search = usp.toString();
+  window.history.pushState({ finalGitUrl, project }, null, url.href);
+
+  // assemble bookmarklet config
+  const segs = new URL(finalGitUrl).pathname.substring(1).split('/');
+  const owner = segs[0];
+  const repo = segs[1];
+  const ref = segs[3] || 'main';
+
+  const config = {
+    owner,
+    repo,
+    ref,
+  };
 
   // pass token
   if (token) {

--- a/tests/blocks/sidekick-generator/sidekick-generator.test.js
+++ b/tests/blocks/sidekick-generator/sidekick-generator.test.js
@@ -36,7 +36,7 @@ describe('Sidekick Generator', () => {
     const generator = document.querySelector('.sidekick-generator');
     await decorate(generator);
     generator.querySelector('#giturl').value = 'https://main--a-customer--hlxsites.hlx.page';
-    generator.querySelector('#project').value = 'Helix Pages';
+    generator.querySelector('#project').value = 'Helix Page';
     generator.querySelector('#generator').click();
 
     const url = new URL(window.location.href);
@@ -48,7 +48,7 @@ describe('Sidekick Generator', () => {
     const generator = document.querySelector('.sidekick-generator');
     await decorate(generator);
     generator.querySelector('#giturl').value = 'https://main--a-customer--hlxsites.hlx.live';
-    generator.querySelector('#project').value = 'Helix Pages';
+    generator.querySelector('#project').value = 'Helix Page';
     generator.querySelector('#generator').click();
 
     const url = new URL(window.location.href);

--- a/tests/blocks/sidekick-generator/sidekick-generator.test.js
+++ b/tests/blocks/sidekick-generator/sidekick-generator.test.js
@@ -36,7 +36,7 @@ describe('Sidekick Generator', () => {
     const generator = document.querySelector('.sidekick-generator');
     await decorate(generator);
     generator.querySelector('#giturl').value = 'https://main--a-customer--hlxsites.hlx.page';
-    generator.querySelector('#project').value = 'Helix Page';
+    generator.querySelector('#project').value = 'Helix Pages';
     generator.querySelector('#generator').click();
 
     const url = new URL(window.location.href);
@@ -48,7 +48,7 @@ describe('Sidekick Generator', () => {
     const generator = document.querySelector('.sidekick-generator');
     await decorate(generator);
     generator.querySelector('#giturl').value = 'https://main--a-customer--hlxsites.hlx.live';
-    generator.querySelector('#project').value = 'Helix Page';
+    generator.querySelector('#project').value = 'Helix Pages';
     generator.querySelector('#generator').click();
 
     const url = new URL(window.location.href);

--- a/tests/blocks/sidekick-generator/sidekick-generator.test.js
+++ b/tests/blocks/sidekick-generator/sidekick-generator.test.js
@@ -32,6 +32,30 @@ describe('Sidekick Generator', () => {
     expect(bookmark.getAttribute('href')).to.equal('#');
   });
 
+  it('works with hlx.page urls', async () => {
+    const generator = document.querySelector('.sidekick-generator');
+    await decorate(generator);
+    generator.querySelector('#giturl').value = 'https://main--a-customer--hlxsites.hlx.page';
+    generator.querySelector('#project').value = 'Helix Page';
+    generator.querySelector('#generator').click();
+
+    const url = new URL(window.location.href);
+    const usp = url.searchParams;
+    expect(usp.get('giturl')).to.equal('https://github.com/hlxsites/a-customer/tree/main');
+  });
+
+  it('works with hlx.live urls', async () => {
+    const generator = document.querySelector('.sidekick-generator');
+    await decorate(generator);
+    generator.querySelector('#giturl').value = 'https://main--a-customer--hlxsites.hlx.live';
+    generator.querySelector('#project').value = 'Helix Page';
+    generator.querySelector('#generator').click();
+
+    const url = new URL(window.location.href);
+    const usp = url.searchParams;
+    expect(usp.get('giturl')).to.equal('https://github.com/hlxsites/a-customer/tree/main');
+  });
+
   it('displays a sidekick bookmarklet link', async () => {
     const generator = document.querySelector('.sidekick-generator');
     await decorate(generator);


### PR DESCRIPTION
## Description

Due to the anchor linking of heading elements, the logic was selecting that link and tying the action there instead of the submit button.

I also made url parsing logic support hlx.live and hlx.page urls while I was in there

## Related Issue

See: #209 

## Motivation and Context

a user sent me a screenshot of the previous experience and was having trouble getting the project added to their sidekick. the user is non technical, and was putting in the hlx.page preview url, so it made sense to me to add support for those as well.

## How Has This Been Tested?

Tested locally to ensure both GitHub and hlx.page/live urls work. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
