### PR TITLE
[#0] Nested page highlighting in side navigation

### DIFF
--- a/blocks/side-navigation/side-navigation.css
+++ b/blocks/side-navigation/side-navigation.css
@@ -115,6 +115,10 @@
   background: #d1e5f5;
 }
 
+.side-navigation-nested-target:has(.list-section-inner-nested li > a.active) {
+  background: aliceblue;
+}
+
 .side-navigation .list-section .list-section-inner-nested {
   display: flex;
   width: 100%;

--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -90,10 +90,6 @@ export default function decorate(block) {
   block.querySelectorAll(':scope > div > div > ul > li').forEach((list) => {
     list.classList.add('list-section');
 
-    list.addEventListener('click', (e) => {
-      e.target.classList.toggle('closed');
-    });
-
     list.querySelector(':scope > a').classList.add('heading');
     list.querySelectorAll(':scope > ul').forEach((listInner) => {
       listInner.classList.add('list-section-inner');
@@ -112,6 +108,11 @@ export default function decorate(block) {
       listInner.querySelectorAll(':scope li a').forEach((link) => {
         if (window.location.pathname === link.getAttribute('href')) {
           link.classList.add('active');
+
+          const nestedParent = link.closest('.side-navigation-nested-target');
+          if (nestedParent) {
+            nestedParent.classList.remove('collapse');
+          }
         }
       });
     });


### PR DESCRIPTION
Update: page highlighting in the side nav for nested pages (ex. Sidekick overview within Sidekick dropdown - intended behaviour: the sidekick section should be open and highlighted) 

Test URLs (In Use):

Before: https://website-redesign--helix-website--adobe.hlx.page/drafts/redesign/documentation
After: https://redesign-side-navigation-update--helix-website--adobe.hlx.page/drafts/redesign/documentation

Sidekick overview page: 
https://redesign-side-navigation-update--helix-website--adobe.hlx.page/drafts/redesign/docs/sidekick-overview
