### PR TITLE
[#0] Block - Breadcrumb

### DIFF
--- a/blocks/breadcrumb/README.md
+++ b/blocks/breadcrumb/README.md
@@ -1,0 +1,28 @@
+## Breadcrumb
+
+Notes: The Breadcrumb block is built automatically into all pages with the Page metadata template set to `guides`. On the guides pages the category in the page metadata should be set to one of the 4 main categories (Build, Publish, Author, Resources). However, this block can also be added to pages outside of the guide template on an as needed basis. 
+
+##### Custom Classes 
+|  Class | Function   |  
+|--------|------------|
+|   Contained |  Respects the max width of all content blocks |  
+
+
+#### Example:
+
+See Live output (Link TBD)
+
+#### Content Structure:
+
+[See Content in Document](https://docs.google.com/document/d/1Ey4CgcbC8ed6uElKIUMYzJVbZyBj6tjfFR_jlR01qfw/edit)
+
+#### Code:
+Side Navigation is styled in the block CSS code.
+
+There is no Javascript code needed for decoration.
+
+[Decoration Code](breadcrumb.js)
+
+The CSS Styling is very project specific and gets adjusted as needed for a project or block by block.
+
+[Styling Code](breadcrumb.css)

--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -1,0 +1,40 @@
+.breadcrumb-wrapper {
+  width: 100%;
+}
+
+.breadcrumb-wrapper:not(.no-shadow) {
+  box-shadow: 0 4px 6px rgba(0 0 0 15%);
+  margin-bottom: var(--spacing-l);
+}
+
+.breadcrumb ul {
+  display: flex;
+  flex-flow: wrap;
+  list-style: none;
+  padding: var(--spacing-xs) 0;
+}
+
+.breadcrumb.contained.block > div > div > ul {
+  margin: 0;
+}
+
+.breadcrumb ul li {
+  padding-right: var(--spacing-xxs);
+  padding-inline-start: 0;
+  font-size: var(--type-body-xxs-size);
+}
+
+.breadcrumb ul li:not(:last-child) a::after  {
+  content: '/';
+  padding-left: var(--spacing-xxs);
+}
+
+.breadcrumb ul li a {
+  text-decoration: none;
+  color: var(--color-black);
+  font-size: var(--type-body-xxs-size);
+}
+
+/* body.guides-template .breadcumb ul {
+  margin: 0;
+} */

--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -31,10 +31,10 @@
 
 .breadcrumb ul li a {
   text-decoration: none;
-  color: var(--color-black);
+  color: var(--color-eyebrow-light-grey);
   font-size: var(--type-body-xxs-size);
 }
 
-/* body.guides-template .breadcumb ul {
-  margin: 0;
-} */
+.breadcrumb ul li:last-of-type a {
+  color: var(--color-black);
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -87,15 +87,20 @@ export function loadPreloadLink() {
   const preloadLinks = [{
     href: `${window.hlx.codeBasePath}/img/colorful-bg.jpg`,
     as: 'image',
+    conditionalSelector: ['.hero', '.colorful-bg'],
   }];
 
   preloadLinks.forEach((preloadLink) => {
     if (!document.querySelector(`head > link[href="${preloadLink.href}"]`)) {
-      const link = document.createElement('link');
-      link.setAttribute('rel', 'preload');
-      link.setAttribute('href', preloadLink.href);
-      link.setAttribute('as', preloadLink.as);
-      document.head.appendChild(link);
+      const shouldPreload = preloadLink.conditionalSelector.some((s) => document.querySelector(s));
+
+      if (shouldPreload) {
+        const link = document.createElement('link');
+        link.setAttribute('rel', 'preload');
+        link.setAttribute('href', preloadLink.href);
+        link.setAttribute('as', preloadLink.as);
+        document.head.appendChild(link);
+      }
     }
   });
 }
@@ -809,9 +814,9 @@ async function loadLazy(doc) {
     }, 500);
   }
 
-  loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
+  loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`, null);
   addFavIcon(`${window.hlx.codeBasePath}/img/icon-aec.png`);
-  // loadPreloadLink();
+  loadPreloadLink();
   setLanguageForAccessibility();
 
   if (getMetadata('supressframe')) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -811,7 +811,7 @@ async function loadLazy(doc) {
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   addFavIcon(`${window.hlx.codeBasePath}/img/icon-aec.png`);
-  // loadPreloadLink();
+  loadPreloadLink();
   setLanguageForAccessibility();
 
   if (getMetadata('supressframe')) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -699,48 +699,52 @@ async function buildSideNavigation() {
 }
 
 function buildDocumentationBreadcrumb() {
-  if (!document.body.classList.contains('guides-template')) return;
+  // if (!document.body.classList.contains('guides-template')) return;
 
-  // TODO: update for launch
-  const root = '/drafts/redesign/';
-  const isDocumentationLanding = window.location.pathname.includes(`${root}documentation`);
+  // // TODO: update for launch
+  // const root = '/drafts/redesign/';
+  // const isDocumentationLanding = window.location.pathname.includes(`${root}documentation`);
 
-  const list = createTag('ul');
-  const home = createTag('li', {}, `<a href="${root}new-home">Home</a>`);
-  const docs = createTag('li', {}, `<a href="${root}documentation">Documentation</a>`);
+  // const list = createTag('ul');
+  // const home = createTag('li', {}, `<a href="${root}new-home">Home</a>`);
+  // const docs = createTag('li', {}, `<a href="${root}documentation">Documentation</a>`);
 
-  list.append(home);
-  list.append(docs);
+  // list.append(home);
+  // list.append(docs);
 
-  const category = getMetadata('category');
-  const title = getMetadata('og:title');
+  // const category = getMetadata('category');
+  // const title = getMetadata('og:title');
 
-  if (category) {
-    const section = createTag('li', {}, `<a href="${root}documentation#${category.toLowerCase()}">${category}</a>`);
-    list.append(section);
-  }
+  // if (category) {
+  //   const section = createTag(
+  //     'li',
+  //     {},
+  //     `<a href="${root}documentation#${category.toLowerCase()}">${category}</a>`
+  //   );
+  //   list.append(section);
+  // }
 
-  if (!isDocumentationLanding) {
-    const article = createTag('li', {}, `<a href="${window.location.pathname}">${title}</a>`);
-    list.append(article);
-  }
+  // if (!isDocumentationLanding) {
+  //   const article = createTag('li', {}, `<a href="${window.location.pathname}">${title}</a>`);
+  //   list.append(article);
+  // }
 
-  const tag = createTag('div');
-  const block = buildBlock('breadcrumb', list);
+  // const tag = createTag('div');
+  // const block = buildBlock('breadcrumb', list);
 
-  block.classList.add('contained');
+  // block.classList.add('contained');
 
-  const main = document.querySelector('main');
+  // const main = document.querySelector('main');
 
-  tag.append(block);
-  main.insertBefore(tag, main.querySelectorAll('.section')[0]);
+  // tag.append(block);
+  // main.insertBefore(tag, main.querySelectorAll('.section')[0]);
 
-  if (isDocumentationLanding) {
-    block.parentElement.classList.add('no-shadow');
-  }
+  // if (isDocumentationLanding) {
+  //   block.parentElement.classList.add('no-shadow');
+  // }
 
-  decorateBlock(block);
-  loadBlock(block);
+  // decorateBlock(block);
+  // loadBlock(block);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -811,7 +811,7 @@ async function loadLazy(doc) {
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   addFavIcon(`${window.hlx.codeBasePath}/img/icon-aec.png`);
-  loadPreloadLink();
+  // loadPreloadLink();
   setLanguageForAccessibility();
 
   if (getMetadata('supressframe')) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -85,7 +85,7 @@ export function loadCSS(href, callback) {
  */
 export function loadPreloadLink() {
   const preloadLinks = [{
-    href: '/img/colorful-bg.jpg',
+    href: `${window.hlx.codeBasePath}/img/colorful-bg.jpg`,
     as: 'image',
   }];
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -698,6 +698,51 @@ async function buildSideNavigation() {
   loadBlock(block);
 }
 
+function buildDocumentationBreadcrumb() {
+  if (!document.body.classList.contains('guides-template')) return;
+
+  // TODO: update for launch
+  const root = '/drafts/redesign/';
+  const isDocumentationLanding = window.location.pathname.includes(`${root}documentation`);
+
+  const list = createTag('ul');
+  const home = createTag('li', {}, `<a href="${root}new-home">Home</a>`);
+  const docs = createTag('li', {}, `<a href="${root}documentation">Documentation</a>`);
+
+  list.append(home);
+  list.append(docs);
+
+  const category = getMetadata('category');
+  const title = getMetadata('og:title');
+
+  if (category) {
+    const section = createTag('li', {}, `<a href="${root}documentation#${category.toLowerCase()}">${category}</a>`);
+    list.append(section);
+  }
+
+  if (!isDocumentationLanding) {
+    const article = createTag('li', {}, `<a href="${window.location.pathname}">${title}</a>`);
+    list.append(article);
+  }
+
+  const tag = createTag('div');
+  const block = buildBlock('breadcrumb', list);
+
+  block.classList.add('contained');
+
+  const main = document.querySelector('main');
+
+  tag.append(block);
+  main.insertBefore(tag, main.querySelectorAll('.section')[0]);
+
+  if (isDocumentationLanding) {
+    block.parentElement.classList.add('no-shadow');
+  }
+
+  decorateBlock(block);
+  loadBlock(block);
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -707,7 +752,6 @@ export function buildAutoBlocks(main) {
     buildHeader();
     buildEmbeds(main);
     buildFooter();
-    // buildSideNavigation();
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);
@@ -779,6 +823,7 @@ async function loadLazy(doc) {
   loadBlock(footer);
 
   buildSideNavigation();
+  buildDocumentationBreadcrumb();
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -699,52 +699,52 @@ async function buildSideNavigation() {
 }
 
 function buildDocumentationBreadcrumb() {
-  // if (!document.body.classList.contains('guides-template')) return;
+  if (!document.body.classList.contains('guides-template')) return;
 
-  // // TODO: update for launch
-  // const root = '/drafts/redesign/';
-  // const isDocumentationLanding = window.location.pathname.includes(`${root}documentation`);
+  // TODO: update for launch
+  const root = '/drafts/redesign/';
+  const isDocumentationLanding = window.location.pathname.includes(`${root}documentation`);
 
-  // const list = createTag('ul');
-  // const home = createTag('li', {}, `<a href="${root}new-home">Home</a>`);
-  // const docs = createTag('li', {}, `<a href="${root}documentation">Documentation</a>`);
+  const list = createTag('ul');
+  const home = createTag('li', {}, `<a href="${root}new-home">Home</a>`);
+  const docs = createTag('li', {}, `<a href="${root}documentation">Documentation</a>`);
 
-  // list.append(home);
-  // list.append(docs);
+  list.append(home);
+  list.append(docs);
 
-  // const category = getMetadata('category');
-  // const title = getMetadata('og:title');
+  const category = getMetadata('category');
+  const title = getMetadata('og:title');
 
-  // if (category) {
-  //   const section = createTag(
-  //     'li',
-  //     {},
-  //     `<a href="${root}documentation#${category.toLowerCase()}">${category}</a>`
-  //   );
-  //   list.append(section);
-  // }
+  if (category) {
+    const section = createTag(
+      'li',
+      {},
+      `<a href="${root}documentation#${category.toLowerCase()}">${category}</a>`,
+    );
+    list.append(section);
+  }
 
-  // if (!isDocumentationLanding) {
-  //   const article = createTag('li', {}, `<a href="${window.location.pathname}">${title}</a>`);
-  //   list.append(article);
-  // }
+  if (!isDocumentationLanding) {
+    const article = createTag('li', {}, `<a href="${window.location.pathname}">${title}</a>`);
+    list.append(article);
+  }
 
-  // const tag = createTag('div');
-  // const block = buildBlock('breadcrumb', list);
+  const tag = createTag('div');
+  const block = buildBlock('breadcrumb', list);
 
-  // block.classList.add('contained');
+  block.classList.add('contained');
 
-  // const main = document.querySelector('main');
+  const main = document.querySelector('main');
 
-  // tag.append(block);
-  // main.insertBefore(tag, main.querySelectorAll('.section')[0]);
+  tag.append(block);
+  main.insertBefore(tag, main.querySelectorAll('.section')[0]);
 
-  // if (isDocumentationLanding) {
-  //   block.parentElement.classList.add('no-shadow');
-  // }
+  if (isDocumentationLanding) {
+    block.parentElement.classList.add('no-shadow');
+  }
 
-  // decorateBlock(block);
-  // loadBlock(block);
+  decorateBlock(block);
+  loadBlock(block);
 }
 
 /**
@@ -811,7 +811,7 @@ async function loadLazy(doc) {
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   addFavIcon(`${window.hlx.codeBasePath}/img/icon-aec.png`);
-  loadPreloadLink();
+  // loadPreloadLink();
   setLanguageForAccessibility();
 
   if (getMetadata('supressframe')) {


### PR DESCRIPTION
Added a breadcrumb block that can be used on its own - but also gets built by default into documentation pages. Related to #236 

Test URLs (block)
Before: https://website-redesign--helix-website--adobe.hlx.page/drafts/redesign/blocks/breadcrumb
After: https://redesign-breadcrumbs--helix-website--adobe.hlx.page/drafts/redesign/blocks/breadcrumb

[Readme](https://github.com/adobe/helix-website/blob/redesign/breadcrumbs/blocks/breadcrumb/README.md)
