### PR TITLE
[#0] Adding back button to documentation pages

### DIFF
--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -6,7 +6,7 @@
 
 .breadcrumb-wrapper:not(.no-shadow) {
   box-shadow: 0 4px 6px rgba(0 0 0 15%);
-  margin-bottom: var(--spacing-l);
+  margin-bottom: var(--spacing-xxxl);
 }
 
 .block.breadcrumb {

--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -35,6 +35,14 @@ export default async function decorate(block) {
   if (!isDocumentationLanding) {
     const article = createTag('li', {}, `<a href="${window.location.pathname}">${title}</a>`);
     list.append(article);
+
+    const backBtn = createTag('div', { class: 'guides-back-btn' }, `
+        <span class="icon icon-icon-arrow"></span>
+        <a href="${root}documentation" class="breadcrumb-link-underline-effect">
+            Back
+        </a>
+    `);
+    document.querySelector('.default-content-wrapper').prepend(backBtn);
   }
 
   block.classList.add('contained');

--- a/blocks/side-navigation/side-navigation.css
+++ b/blocks/side-navigation/side-navigation.css
@@ -14,6 +14,16 @@
   min-height: 135px;
 }
 
+.side-navigation-wrapper,
+.side-navigation-wrapper + .section.content {
+  display: none;
+}
+
+.side-navigation-wrapper.ready,
+.side-navigation-wrapper.ready + .section.content {
+  display: block;
+}
+
 .side-navigation-wrapper > div {
   max-width: var(--grid-mobile-container-width);
   margin-left: auto;
@@ -134,6 +144,8 @@
   width: 100%;
   border-radius: var(--nav-sidebar-link-border-radius);
   transition: var(--nav-sidebar-transition);
+  display: flex;
+  justify-content: space-between;
 }
 
 .side-navigation .list-section .list-section-inner li a:hover {
@@ -201,7 +213,7 @@
 }
 
 
-.side-navigation .list-section .side-navigation-nested-target:not(.collapse) .icon {
+.side-navigation .list-section .side-navigation-nested-target:not(.collapse) .icon.icon-icon-caret-down {
   transform: rotate(180deg);
 }
 

--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -144,6 +144,8 @@ export default async function decorate(block) {
     });
   });
 
+  block.parentElement.classList.add('ready');
+
   const resizeContent = () => {
     if (window.innerWidth > MOBILE_BREAKPOINT) {
       block.classList.remove('overlay');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -856,6 +856,10 @@ body.docs-template main p {
     } */
 }
 
+body.guides-template main.without-full-width-hero {
+  min-height: 900px;
+} 
+
 .docs-template a.button.accent:any-link {
   background-color: var(--spectrum-blue);
   border-color: var(--spectrum-blue);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -931,7 +931,7 @@ body.guides-template .default-content-wrapper a {
   overflow-wrap: break-word;
 }
 
-body.guides-template main .default-content-wrapper > :first-of-type {
+body.guides-template main .default-content-wrapper > :first-of-type:not(.guides-back-btn) {
   margin-top: 0;
 }
 
@@ -949,7 +949,9 @@ body.guides-template main.without-full-width-hero .default-content-wrapper h3 {
 body.guides-template main.without-full-width-hero .default-content-wrapper img:first-of-type {
   width: 100%;
   height: auto;
+  object-fit: cover;
   aspect-ratio: 16 / 9;
+  border-radius: 50px;
 }
 
 /* for guides-template with hero section (.heading), like documentation category page */
@@ -966,13 +968,26 @@ body.guides-template main.has-full-width-hero .card-list-wrapper {
   margin-bottom: var(--spacing-m);
 }
 
+/* guides-template back button on documentation detail pages */
+body.guides-template .guides-back-btn {
+  margin: var(--spacing-s) 0;
+  display: flex;
+  align-items: center;
+}
+
+body.guides-template .guides-back-btn a {
+  text-decoration: none;
+}
+
+body.guides-template .guides-back-btn span {
+  margin-right: var(--spacing-xxs);
+}
 
 @media screen and (min-width: 768px) {
   body.guides-template main.has-full-width-hero .section.heading  {
     padding-bottom: var(--spacing-s);
   }
 }
-
 
 @media screen and (min-width: 900px) {
   body.guides-template main {
@@ -1004,6 +1019,10 @@ body.guides-template main.has-full-width-hero .card-list-wrapper {
     margin-top: var(--spacing-ml);
     margin-bottom: var(--spacing-m);
   }
+
+  body.guides-template .guides-back-btn {
+    margin: -56px 0 var(--spacing-m);
+  }
 }
 
 body.guides-template main .section.content .default-content-wrapper {
@@ -1012,7 +1031,8 @@ body.guides-template main .section.content .default-content-wrapper {
 }
 
 body.guides-template .icon-icon-caret-right,
-body.guides-template .icon-icon-caret-down {
+body.guides-template .icon-icon-caret-down,
+body.guides-template .icon-icon-arrow {
   width: 20px;
   height: 20px;
   background-repeat: no-repeat;
@@ -1024,6 +1044,10 @@ body.guides-template .icon-icon-caret-right {
 
 body.guides-template .icon-icon-caret-down {
   background-image: url("/img/icon-caret-down.svg");
+}
+
+body.guides-template .guides-back-btn .icon-icon-arrow {
+  background-image: url("/img/icon-arrow.svg");
 }
 
 /* ---- Utility Classes ---- */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -951,7 +951,7 @@ body.guides-template main.without-full-width-hero .default-content-wrapper img:f
   height: auto;
   object-fit: cover;
   aspect-ratio: 16 / 9;
-  border-radius: 50px;
+  border-radius: 20px;
 }
 
 /* for guides-template with hero section (.heading), like documentation category page */


### PR DESCRIPTION
Updating breadcrumbs to also inject a back button to the main content area that leads back to the documentation page.

Test URLs
Before: https://website-redesign--helix-website--adobe.hlx.page/drafts/redesign/docs/anatomy-of-a-helix-project 
After: https://redesign-doc-detail-page--helix-website--adobe.hlx.page/drafts/redesign/docs/anatomy-of-a-helix-project