### PR TITLE
handling long descriptions

### DIFF
--- a/blocks/card-list/card-list.css
+++ b/blocks/card-list/card-list.css
@@ -1,4 +1,13 @@
-.card-list-wrapper .cards .cards-card-details dialog[aria-expanded="true"] {
+
+.card-list-wrapper .cards .cards-card-details p.description:not([aria-expanded="true"]):not(.noextra)::after {
+  content: '...';
+}
+
+.card-list-wrapper .cards .cards-card-details span.extra:not([aria-expanded="true"]) {
+  display: none;
+}
+
+.card-list-wrapper .cards .cards-card-details span.extra[aria-expanded="true"] {
   display: contents;
   color: inherit;
 }

--- a/blocks/card-list/card-list.js
+++ b/blocks/card-list/card-list.js
@@ -1,8 +1,8 @@
 import { buildBlock, decorateBlock, loadBlock } from '../../scripts/scripts.js';
 
-function toggleVisibility(dialog) {
-  const expanded = dialog.getAttribute('aria-expanded') === 'true';
-  dialog.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+function toggleVisibility(el) {
+  const expanded = el.getAttribute('aria-expanded') === 'true';
+  el.setAttribute('aria-expanded', expanded ? 'false' : 'true');
 }
 
 function urlify(str) {
@@ -14,6 +14,14 @@ function stripTags(html, ...args) {
     if (args.includes(tag)) return `<${endMark}${tag}>`;
     return '';
   }).replace(/<!--.*?-->/g, '');
+}
+
+function truncate(str, limit) {
+  const words = str.trim().split(' ');
+  const initial = words.slice(0, limit);
+  const extra = words.slice(limit);
+  if (extra.length < 1) return `<p class="description noextra">${initial.join(' ')}</p>`;
+  return `<p class="description">${initial.join(' ')} <span class='extra'>${extra.join(' ')}</span></p>`;
 }
 
 export default async function decorate(block) {
@@ -38,7 +46,7 @@ export default async function decorate(block) {
       }
       cardDetails += `<p><em>${stripTags(row.category)}</em></p>
       <p><em>${stripTags(row.firstName)} ${stripTags(row.lastName)}, ${stripTags(row.company)}</em></p>
-      <p class="description">${urlify(stripTags(row.description), 'b', 'i', 'u', 'p', 'br')}</p>`;
+      ${truncate(urlify(stripTags(row.description), 'b', 'i', 'u', 'p', 'br'), 25)}`;
       cardsRow.push(cardDetails);
     });
     cardsArr.push(cardsRow);
@@ -54,11 +62,12 @@ export default async function decorate(block) {
     await loadBlock(cardsBlock);
 
     // add listener to hide/show the description overflow dialog
-    const dialogs = blockWrapper.querySelectorAll('.cards-card dialog');
-    dialogs.forEach((dialog) => {
-      const description = dialog.parentElement.querySelector('p.description');
+    const extras = blockWrapper.querySelectorAll('.cards-card span.extra');
+    extras.forEach((el) => {
+      const description = el.parentElement;
       description.addEventListener('click', (event) => {
-        toggleVisibility(dialog);
+        toggleVisibility(el);
+        toggleVisibility(description);
         event.stopPropagation();
       });
     });


### PR DESCRIPTION
Truncating long descriptions to 25 words and showing the extra on toggle click of description

Before: https://main--helix-website--adobe.hlx.page/drafts/amol/block-collection
After: https://main--helix-website--amol-anand.hlx.page/drafts/amol/block-collection

Look at the block party card list at the bottom of the page to see the difference.