### PR TITLE
Redesign: support cta button list in documentation hero

### DIFF
--- a/blocks/hero/README.md
+++ b/blocks/hero/README.md
@@ -8,7 +8,7 @@ Notes:
 | N/A |  Default Home Hero: text in center, image at bottom, colorful checkerboard pattern background |  
 | side-by-side | 50% detail, 50% image in same row  |  
 | square-image | image will become 1:1 in aspect ratio  |  
-| mutiple-cta  | decorate multiple cta buttons with different styles (TBC) |
+| mutiple-cta  | decorate multiple cta buttons with black border styles (ul a) |
 
 #### Example:
 
@@ -24,6 +24,10 @@ https://docs.google.com/document/d/1LfT3loAme82XIWhWAUOaWK1aPP42XzZ1GVjwHYtk0Zc/
 #### Code:
 - Background Image: display image from 1st table row as cover. If no image provided, it will fallback to default grey checkerboard background
 - Text Content from 2nd table row
+    - h1 -> heading
+    - a -> cta-button
+    - p -> description
+    - ul list with multiple <a> elements -> cta button list (need to use with .multple-cta on block)
 - Content Image from 3rd table row
 
 [Decoration Code](hero.js)

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -208,3 +208,28 @@
     aspect-ratio: 1 / 1;
     object-fit: cover;
 }
+
+/* - hero.multiple-cta - */
+.hero.multiple-cta ul.cta-button-list {
+    display: flex;
+    list-style: none;
+    padding-left: 0;
+    margin-top: 30px;
+}
+
+.hero.multiple-cta ul.cta-button-list .button{
+    margin-left: 0;
+    margin-bottom: 0;
+}
+
+@media screen and (min-width: 600px) {
+    .hero.multiple-cta ul.cta-button-list {
+        margin-top: 8px;
+    }
+}
+
+@media screen and (min-width: 900px) {
+    .hero.multiple-cta ul.cta-button-list {
+        margin-top: 16px;
+    }
+}

--- a/blocks/hero/hero.js
+++ b/blocks/hero/hero.js
@@ -15,7 +15,12 @@ export default function decorate(block) {
       ctaButton.closest('p').replaceWith(ctaButton);
     }
   } else {
-    // TODO: decorate multiple cta buttons here, like doc hero
+    const ctaButtonList = innerContent.querySelector('ul');
+    ctaButtonList.classList.add('cta-button-list');
+    const ctaButtons = ctaButtonList.querySelectorAll('ul a');
+    ctaButtons.forEach((btn) => {
+      btn.classList.add('button', 'large', 'black-border');
+    });
   }
 
   const imageWrapper = block.children[2].querySelector('div');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -147,7 +147,7 @@
     --nav-height: 65px;
 
     /* breadcrumb */
-    --breadcrumb-height: 0;
+    --breadcrumb-height: 1px;
 
     /* Checkerboard pattern */
     --color-checkerboard-bg-border: rgb(214 213 213 / 40%);
@@ -786,7 +786,7 @@ main .form .button:hover::before {
   left: 0%;
 }
 
-/* secondary button: grey button */
+/* secondary button: grey border transparent bg -> border button */
 .redesign a.button.secondary:any-link {
   color: var(--color-font-grey);
   border-color: var(--color-font-grey);
@@ -799,6 +799,21 @@ main .form .button:hover::before {
 .redesign a.button.secondary:any-link::before {
   /* 1st value: hovered color, 2nd value: original color */
   background: radial-gradient(circle at left, var(--color-font-grey) 50%, transparent 50%);
+}
+
+/* .black-border button: black border transparent bg -> border button */
+.redesign a.button.black-border:any-link {
+  color: var(--color-black);
+  border-color: var(--color-black);
+}
+
+.redesign a.button.black-border:any-link:hover {
+  color: var(--color-white);
+}
+
+.redesign a.button.black-border:any-link::before {
+  /* 1st value: hovered color, 2nd value: original color */
+  background: radial-gradient(circle at left, rgb(0 0 0 / 50%) 50%, transparent 50%);
 }
 
 /* larger size */


### PR DESCRIPTION
Fix for issue:
#298 support cta buttons list in documentation hero

Note:
- need to use with `.multiple-cta` on `hero` block for the button list style

Google Doc:
https://docs.google.com/document/d/197AUaVWYZw-DCzYinzOJn3F5PcncZ0JT5KuvLWR2JVM/edit

Test URLs:
Before: https://website-redesign--helix-website--adobe.hlx.page/drafts/redesign/documentation
After: https://redesign-doc-hero-update--helix-website--adobe.hlx.page/drafts/redesign/documentation