### PR TITLE
Redesign/nav footer migrate

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -120,8 +120,7 @@ export default async function decorate(block) {
   block.textContent = '';
   block.classList.add('contained');
 
-  // TODO: need to update the path when migrate
-  const footerPath = cfg.footer || '/drafts/redesign/new-footer';
+  const footerPath = cfg.footer || '/new-footer';
   const resp = await fetch(`${footerPath}.plain.html`);
   const html = await resp.text();
 

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -35,6 +35,12 @@ const decorateDesktopFooterNav = (footerNavSection, ctaButton) => {
       navLinks.forEach((navLink) => {
         navLink.setAttribute('target', returnLinkTarget(navLink.href));
         navLink.classList.add('link-underline-effect');
+
+        // TODO: temp fix for status.live
+        if (navLink.textContent.toLowerCase() === 'status.live') {
+          navLink.setAttribute('href', 'https://status.hlx.live/');
+          navLink.setAttribute('target', '_blank');
+        }
       });
 
       // clone the node

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -246,10 +246,15 @@ class Gnav {
       submenuLink.innerHTML = '';
       submenuLink.setAttribute('target', returnLinkTarget(submenuLink.href));
 
+      // TODO: temp fix for status.live, can be remove if subdomain is supported
+      if (submenuTitleText.toLowerCase() === 'status.live') {
+        submenuLink.setAttribute('href', 'https://status.hlx.live/');
+        submenuLink.setAttribute('target', '_blank');
+      }
+
       const submenuIcon = item.querySelector('span.icon');
       if (submenuIcon) {
         this.decorateIcon(submenuIcon, submenuTitleText);
-
         const iconWrapper = createTag('div', {
           class: `icon-wrapper colored-tag circle ${currentColorPattern[idx]}`,
         }, '');

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -500,7 +500,7 @@ async function fetchGnav(url) {
 
 export default async function init(blockEl) {
   // OLD CODE: const url = getMetadata('gnav') || '/gnav';
-  const url = '/drafts/redesign/new-nav';
+  const url = '/new-nav';
   const html = await fetchGnav(url);
 
   if (html) {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -278,9 +278,13 @@ class Gnav {
         this.closeMenu();
       });
 
+      const removeTrailingSlash = (url) => url.replace(/\/$/, '');
+
       // add active status to main link
       const navUrlObject = new URL(submenuLink.href);
-      if (window.location.pathname.includes(navUrlObject.pathname)) {
+      const currentPathWithoutTrailingSlash = removeTrailingSlash(window.location.pathname);
+      const linkPathWithoutTrailingSlash = removeTrailingSlash(navUrlObject.pathname);
+      if (currentPathWithoutTrailingSlash === linkPathWithoutTrailingSlash) {
         navMainLink.classList.add('active');
       }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -818,7 +818,6 @@ async function loadEager(doc) {
   }
 }
 
-// TODO:
 function addBlockLevelInViewAnimation(main) {
   const observerOptions = {
     threshold: 0.2, // add `.in-view` class when is 20% in view
@@ -855,7 +854,6 @@ async function loadLazy(doc) {
   // NOTE:'.redesign' class is needed for the redesign styles, keep this
   document.body.classList.add('redesign');
 
-  // TODO: test in view animation
   loadBlocks(main);
   addBlockLevelInViewAnimation(main);
 


### PR DESCRIPTION
Changes: 
- Updated `footer` and `header` fetching path 
- `header` active style logic minor updates
- temp fix in `header` & `footer` for supporting the subdomain `https://status.hlx.live/`

NOTE: 
- added temp fix for supporting `https://status.hlx.live/` subdomain in codebase, as by default the subdomain link will change into `/` after fetching directly in codebase (cannot get `https://status.hlx.live/` in codebase side). This problem occurs in whole codebase -> need to ask if Adobe team know where they perform the checking on subdomains to route to `/` & if it's possible to support `subdomain` in link
- temp fix in header & footer is checking text content of the link, if it's `status.live`, it'll change the url to `https://status.hlx.live/` for now. If the above issue is fixed, the temp fix can be removed.

Test Urls (home)
Before: https://website-redesign--helix-website--adobe.hlx.page/contact
After: https://redesign-nav-footer-migrate--helix-website--adobe.hlx.page/contact