### PR TITLE
Redesign/doc migration

### DIFF
--- a/blocks/card-list/README.md
+++ b/blocks/card-list/README.md
@@ -5,7 +5,8 @@ Notes: This block closely resembles the layout of the cards block in the helix b
 ##### Custom Classes 
 |  Class | Function   |  
 |--------|------------|
-|   - |  -   |  
+|  N/A   | input link only in doc & render `cards` block based on content |  
+| .image-card-listing | decorate the card list using content including image & text |
 
 
 #### Example:

--- a/blocks/card-list/card-list.css
+++ b/blocks/card-list/card-list.css
@@ -67,3 +67,25 @@
     grid-gap: var(--spacing-s);
   }
 }
+
+/* block party card list style */
+.card-list-wrapper .cards .cards-card-details p.description:not(.noextra){
+  cursor: pointer;
+}
+
+.card-list-wrapper .cards .cards-card-details p.description:not([aria-expanded="true"]):not(.noextra)::after {
+  content: '...';
+}
+
+.card-list-wrapper .cards .cards-card-details span.extra:not([aria-expanded="true"]) {
+  display: none;
+}
+
+.card-list-wrapper .cards .cards-card-details span.extra[aria-expanded="true"] {
+  display: contents;
+  color: inherit;
+}
+
+.card-list-wrapper .cards .cards-card-details {
+  overflow-x: hidden;
+}

--- a/blocks/card-list/card-list.js
+++ b/blocks/card-list/card-list.js
@@ -1,6 +1,11 @@
-import { createOptimizedPicture, createTag } from '../../scripts/scripts.js';
+// NOTE: combined same name `card-list` blocks in redesign & main branch here,
+//  note can be removed after approval
+import {
+  createOptimizedPicture, createTag, buildBlock, decorateBlock, loadBlock,
+} from '../../scripts/scripts.js';
 
-export default function decorate(block) {
+// Redesign's version: render image card list
+const decorateCardListByListElement = (block) => {
   /* change to ul, li */
   const ul = document.createElement('ul');
 
@@ -33,4 +38,99 @@ export default function decorate(block) {
   ul.querySelectorAll('img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
   block.textContent = '';
   block.append(ul);
+};
+
+// Adobe's version: render cards block by url
+function toggleVisibility(el) {
+  const expanded = el.getAttribute('aria-expanded') === 'true';
+  el.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+}
+
+function urlify(str) {
+  return str.replace(/(https:\/\/[^ "]+)/g, (url) => `<a href="${url}" target="_blank">Link</a>`);
+}
+
+function stripTags(html, ...args) {
+  return html.replace(/<(\/?)(\w+)[^>]*\/?>/g, (_, endMark, tag) => {
+    if (args.includes(tag)) return `<${endMark}${tag}>`;
+    return '';
+  }).replace(/<!--.*?-->/g, '');
+}
+
+function truncate(str, limit) {
+  const words = str.trim().split(' ');
+  const initial = words.slice(0, limit);
+  const extra = words.slice(limit);
+  if (extra.length < 1) return `<p class="description noextra">${initial.join(' ')}</p>`;
+  return `<p class="description">${initial.join(' ')} <span class='extra'>${extra.join(' ')}</span></p>`;
+}
+
+async function decorateCardListByUrl(block) {
+  if (block.classList.contains('image-card-listing')) return;
+  const endpoint = block.querySelector('a').href;
+  block.textContent = '';
+  const blockParty = await fetch(endpoint);
+  const blockPartyJson = await blockParty.json();
+  if (blockPartyJson.data && (blockPartyJson.data.length > 0)) {
+    // create a 2D array to pass to the cards block
+    const cardsArr = [];
+    let cardsRow = [];
+    const blockPartyList = blockPartyJson.data.filter((row) => row.approved === 'true');
+    await blockPartyList.forEach(async (row, i) => {
+      // limit each row to only 2 columns, otherwise create a new row
+      if ((i !== 0) && (i % 2) === 0) {
+        cardsArr.push(cardsRow);
+        cardsRow = [];
+      }
+      let githubName = '';
+      if (row.githubProfile && (row.permission === 'on')) {
+        const ghProfile = stripTags(row.githubProfile).split('/');
+        const ghUsername = ghProfile[ghProfile.length - 1];
+        if (ghUsername) {
+          githubName = `<code>${ghUsername}</code>`;
+        } else {
+          githubName = `<code>${stripTags(row.githubProfile)}</code>`;
+        }
+      }
+      let cardDetails = `<p class="block-party-card-title"><em>${stripTags(row.category)}</em>${githubName}</p>`;
+      cardDetails += `<p><a href="${stripTags(row.githubUrl)}" target="_blank">${stripTags(row.title)}</a></p>`;
+      if (row.showcaseUrl) {
+        cardDetails += `<p><a href="${stripTags(row.showcaseUrl)}" target="_blank">Preview</a></p>`;
+      }
+      cardDetails += `${truncate(urlify(stripTags(row.description), 'b', 'i', 'u', 'p', 'br'), 25)}`;
+      cardsRow.push(cardDetails);
+    });
+    cardsArr.push(cardsRow);
+
+    // build out cards using the existing cards block
+    const cardsBlock = buildBlock('cards', cardsArr);
+    // replace existing block with the new cards block
+    const blockWrapper = block.parentElement;
+    block.remove();
+    blockWrapper.append(cardsBlock);
+    // decorate and load the cards block
+    decorateBlock(cardsBlock);
+    await loadBlock(cardsBlock);
+
+    // add listener to hide/show the description overflow dialog
+    const extras = blockWrapper.querySelectorAll('.cards-card span.extra');
+    extras.forEach((el) => {
+      const description = el.parentElement;
+      description.addEventListener('click', (event) => {
+        toggleVisibility(el);
+        toggleVisibility(description);
+        event.stopPropagation();
+      });
+    });
+  }
+}
+
+// `.image-card-listing` is added to `card list` block on documentation
+// category page in Guide template by default: See updateGuideTemplateStyleBasedOnHero
+export default async function decorate(block) {
+  if (block.classList.contains('image-card-listing')) {
+    decorateCardListByListElement(block);
+  } else {
+    decorateCardListByUrl(block);
+  }
 }

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,5 +1,5 @@
 .cards {
-    padding: 0 0.5rem;
+    padding: 0;
     margin: 2rem 0;
 }
 
@@ -16,9 +16,14 @@
     justify-content: left;
 }
 
+.cards > div:last-of-type {
+    justify-content: left;
+}
+
 .cards a:any-link {
     color: currentcolor;
-    font-size: 24px;
+    font-size: var(--type-heading-m-size);
+    line-height: var(--type-heading-m-lh);
     text-decoration: none;
     display: block;
     position: relative;
@@ -28,13 +33,19 @@
     content: '❯';
     position: absolute;
     right: 0;
+    transition: all 0.3s ease-in-out;
+}
+
+.cards a:hover:any-link::after {
+    color: var(--spectrum-blue);
+    transform: translateX(3px);
 }
 
 .cards .cards-card {
     width: 100%;
     box-sizing: border-box;
     margin: 0.5rem;
-    background-color: #eee;
+    background: var(--bg-color-lightgrey);
     min-height: 160px;
     opacity: 0;
     transform: translate(0, 50px);
@@ -83,15 +94,21 @@
 }
 
 .cards .cards-card-details {
-    padding: 1rem;
+    padding: 1rem 1rem 1.5rem;
 }
 
 .cards .cards-card-details p:last-of-type {
     margin-bottom: 0;
 }
 
+.cards .block-party-card-title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
 @media (min-width: 900px) {
-    .cards.three .cards-card, .cards.four .cards-card {
+    .cards.two .cards-card, .cards.three .cards-card, .cards.four .cards-card {
         width: calc(50% - 1rem);
     }
 }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -24,6 +24,12 @@ export default function decorate(block) {
       } else if (details.querySelector('h3')) {
         cell.classList.add('cards-card-highlight');
       }
+      // highlight styling
+      const links = details.querySelectorAll('a');
+      links.forEach((link) => {
+        link.classList.add('link-highlight-colorful-effect-hover-wrapper');
+        link.innerHTML = `<span class="link-highlight-colorful-effect-2">${link.textContent}</span>`;
+      });
       cell.append(details);
       observer.observe(cell);
     }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -11,6 +11,12 @@
   }
 }
 
+/* fix for fragment rendering main twice causing extra div
+* can be removed if the fragement bug is fixed */
+.header-wrapper > .header:not(.block) {
+  display: none;
+}
+
 .gnav-wrapper {
   position: relative;
   background: #FFF;

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -1,5 +1,37 @@
+.table {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--bg-color-grey);
+  padding: var(--spacing-xxs) var(--spacing-xxs) var(--spacing-xs);
+}
+
+.table tbody {
+  width: 100%;
+}
+
+.table td,
+body main .table td p {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+  color: var(--color-light-grey-600);
+}
+
 .table td {
-  color: #768390;
+  padding: var(--spacing-xxs) var(--spacing-xxs) 0 var(--spacing-xxs);
+}
+
+body main .table td p {
+  padding-left: 0; 
+}
+
+.table tr:first-of-type {
+  border-bottom: 1px solid var(--bg-color-grey);
+}
+
+.table tr:first-of-type td {
+  text-transform: uppercase;
+  padding-top: var(--spacing-xxs);
+  padding-bottom: var(--spacing-xxs);
 }
 
 .table td:first-child {

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -32,6 +32,7 @@ body main .table td p {
   text-transform: uppercase;
   padding-top: var(--spacing-xxs);
   padding-bottom: var(--spacing-xxs);
+  color: var(--color-black);
 }
 
 .table td:first-child {

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -1,3 +1,4 @@
 export default function decorate() {
   // nothing to do here
+  // ?? console.log here for block by fragment will have no effect
 }

--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -1,3 +1,8 @@
+.video-wrapper {
+    width: 100%;
+    overflow: hidden;       
+}
+
 .video {
     margin: 32px 0;
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -787,6 +787,9 @@ function updateGuideTemplateStyleBasedOnHero() {
 
   if (isHeroContentExist) {
     document.querySelector('main').classList.add('has-full-width-hero');
+    const cardListBlocks = document.querySelectorAll('.block.card-list');
+    // make card list in main category page has '.image-card-listing' class
+    cardListBlocks.forEach((block) => block.classList.add('image-card-listing'));
   } else {
     document.querySelector('main').classList.add('without-full-width-hero');
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -740,6 +740,20 @@ export async function decorateGuideTemplateCodeBlock() {
   });
 }
 
+// patch fix for table not being rendered as block in fragment
+export function decorateFragmentTable(main) {
+  if (!main) return;
+  const tables = main.querySelectorAll('table');
+  if (tables) {
+    tables.forEach((table) => {
+      if (table.classList.contains('block')) return;
+      const tableWrapper = createTag('div', { class: 'table' });
+      table.parentNode.insertBefore(tableWrapper, table);
+      tableWrapper.appendChild(table);
+    });
+  }
+}
+
 export function decorateGuideTemplate(main) {
   if (!document.body.classList.contains('guides-template') || !main) return;
   addMessageBoxOnGuideTemplate(main);
@@ -747,6 +761,7 @@ export function decorateGuideTemplate(main) {
   decorateGuideTemplateHero(main);
   decorateGuideTemplateLinks(main);
   decorateGuideTemplateCodeBlock();
+  decorateFragmentTable(main); // ususally only use fragment in doc detail
 }
 
 /**
@@ -823,6 +838,7 @@ export function decorateMain(main) {
   decorateGuideTemplate(main);
   decorateBlocks(main);
   decorateTitleSection(main);
+  // decorateTableBlock(main);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -647,7 +647,9 @@ export function addHeadingAnchorLink(elem) {
 
 export function decorateGuideTemplateHeadings(main) {
   const contentArea = main.querySelector('.section.content');
+  if (!contentArea) return;
   const contentSections = contentArea.querySelectorAll('.default-content-wrapper');
+  if (!contentSections) return;
   contentSections.forEach((section) => {
     section.querySelectorAll('h2, h3, h4, h5, h6').forEach((h) => {
       addHeadingAnchorLink(h);
@@ -657,9 +659,8 @@ export function decorateGuideTemplateHeadings(main) {
 
 export function decorateGuideTemplateHero(main) {
   if (main.classList.contains('without-full-width-hero'));
-  const contentArea = main.querySelector('.section.content');
-  const firstImage = contentArea.querySelector('.default-content-wrapper img');
-  if (firstImage) firstImage.classList.add('doc-detail-hero-image');
+  const firstImageInContentArea = main.querySelector('.section.content .default-content-wrapper img');
+  if (firstImageInContentArea) firstImageInContentArea.classList.add('doc-detail-hero-image');
 }
 
 export function decorateGuideTemplateLinks(main) {
@@ -740,7 +741,7 @@ export async function decorateGuideTemplateCodeBlock() {
 }
 
 export function decorateGuideTemplate(main) {
-  if (!document.body.classList.contains('guides-template')) return;
+  if (!document.body.classList.contains('guides-template') || !main) return;
   addMessageBoxOnGuideTemplate(main);
   decorateGuideTemplateHeadings(main);
   decorateGuideTemplateHero(main);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -15,7 +15,7 @@
  * @param {string} checkpoint identifies the checkpoint in funnel
  * @param {Object} data additional data for RUM sample
  */
-import { addInViewAnimationToSingleElement, addInViewAnimationToMultipleElements } from '../utils/helpers.js';
+import { addInViewAnimationToSingleElement, addInViewAnimationToMultipleElements, returnLinkTarget } from '../utils/helpers.js';
 
 export function sampleRUM(checkpoint, data = {}) {
   try {
@@ -655,6 +655,20 @@ export function decorateGuideTemplateHeadings(main) {
   });
 }
 
+export function decorateGuideTemplateHero(main) {
+  if (main.classList.contains('without-full-width-hero'));
+  const contentArea = main.querySelector('.section.content');
+  const firstImage = contentArea.querySelector('.default-content-wrapper img');
+  if (firstImage) firstImage.classList.add('doc-detail-hero-image');
+}
+
+export function decorateGuideTemplateLinks(main) {
+  const links = main.querySelectorAll('.content a');
+  links.forEach((link) => {
+    link.setAttribute('target', returnLinkTarget(link.href));
+  });
+}
+
 function animateTitleSection(section) {
   const animationConfig = {
     staggerTime: 0.3,
@@ -729,6 +743,8 @@ export function decorateGuideTemplate(main) {
   if (!document.body.classList.contains('guides-template')) return;
   addMessageBoxOnGuideTemplate(main);
   decorateGuideTemplateHeadings(main);
+  decorateGuideTemplateHero(main);
+  decorateGuideTemplateLinks(main);
   decorateGuideTemplateCodeBlock();
 }
 
@@ -818,7 +834,6 @@ async function loadEager(doc) {
   }
 }
 
-// TODO:
 function addBlockLevelInViewAnimation(main) {
   const observerOptions = {
     threshold: 0.2, // add `.in-view` class when is 20% in view
@@ -855,7 +870,6 @@ async function loadLazy(doc) {
   // NOTE:'.redesign' class is needed for the redesign styles, keep this
   document.body.classList.add('redesign');
 
-  // TODO: test in view animation
   loadBlocks(main);
   addBlockLevelInViewAnimation(main);
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -458,6 +458,7 @@ strong a {
 
 pre {
   overflow-x: scroll;
+  width: 100%;
 }
 
 /* inline code styles */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1196,12 +1196,18 @@ body.guides-template main.without-full-width-hero .default-content-wrapper h3 {
   letter-spacing: 0;
 }
 
-body.guides-template main.without-full-width-hero .default-content-wrapper img:first-of-type {
+body.guides-template main.without-full-width-hero .doc-detail-hero-image {
   width: 100%;
   height: auto;
   object-fit: cover;
   aspect-ratio: 16 / 9;
   border-radius: var(--image-border-radius-l);
+}
+
+body.guides-template main.without-full-width-hero .default-content-wrapper img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* for guides-template with hero section (.heading), like documentation category page */
@@ -1298,7 +1304,7 @@ body.guides-template .guides-back-btn span {
     padding-bottom: var(--spacing-s);
   }
 
-  body.guides-template main.without-full-width-hero .default-content-wrapper img:first-of-type {
+  body.guides-template main.without-full-width-hero .doc-detail-hero-image {
     border-radius: var(--image-border-radius-xxl);
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -457,7 +457,6 @@ strong a {
 }
 
 pre {
-  overflow-x: scroll;
   width: 100%;
 }
 
@@ -1186,6 +1185,12 @@ body.guides-template main .default-content-wrapper > :first-of-type:not(.guides-
   margin-top: 0;
 }
 
+body.guides-template .form {
+  filter: none;
+  box-shadow: 0 0 20px var(--bg-color-grey);
+  margin: var(--spacing-s) 0 var(--spacing-l);
+}
+
 /* for guides-template without hero section (.heading), like documentation detail page */
 
 body.guides-template main.without-full-width-hero .default-content-wrapper h1 {
@@ -1207,8 +1212,7 @@ body.guides-template main.without-full-width-hero .doc-detail-hero-image {
 
 body.guides-template main.without-full-width-hero .default-content-wrapper img {
   display: block;
-  margin-left: auto;
-  margin-right: auto;
+  margin: var(--spacing-s) auto var(--spacing-xs);
 }
 
 /* for guides-template with hero section (.heading), like documentation category page */


### PR DESCRIPTION
UI fixes & Updates for doc detail migration
- open external link in new tab in `doc` pages
- fix video overflowing on mobile 
- combined `card-list` same name blocks into single block, adobe has `card-list` block as well. Now when `.image-card-listing` class is present, it'll change to `redesign` version, default it uses Adobe's version, which renders `cards` block based on url **
- added `.image-card-listing` to card-list in guideTemplate category pages by default, for other `card-list` usage in other places, we may need to add `.image-card-listing` manually
- restyled `cards` styles in block party section (Block Collection)
- restyled `table` block + table mobile responsive fix
- patch fix on table not loading as block when using fragment (can be removed if table is rendered as block)

Fix:
#310 hero image style fix & image in doc detail style fix
#311 Fragment not loading

Test Urls:
Block Collection
Before: https://website-redesign--helix-website--adobe.hlx.page/developer/block-collection
After: https://redesign-doc-migration--helix-website--adobe.hlx.page/developer/block-collection

Getting Started Tutorial (#310)
Before: https://website-redesign--helix-website--adobe.hlx.page/developer/tutorial
After: https://redesign-doc-migration--helix-website--adobe.hlx.page/developer/tutorial

Cloudflare Setup (#311)
Before: https://website-redesign--helix-website--adobe.hlx.page/docs/byo-cdn-cloudflare-worker-wrangler-setup
After: https://redesign-doc-migration--helix-website--adobe.hlx.page/docs/byo-cdn-cloudflare-worker-wrangler-setup
