### PR TITLE
fix(testimonials): close bracket in css expression

### DIFF
--- a/blocks/testimonials/testimonials.js
+++ b/blocks/testimonials/testimonials.js
@@ -91,7 +91,8 @@ export default function decorate(block) {
 
   rows.forEach((row, index) => {
     const tabListContent = row.querySelector(':scope > div:first-child');
-    const tabListTitle = tabListContent.querySelector('p:not(:empty):not(:has(picture))');
+    const tabListTitle = Array.from(tabListContent.querySelectorAll('p:not(:empty)'))
+      .filter((p) => p.querySelector('picture') === null)[0]; // workaround for missing :has() selector in Firefox
     const tabListImage = tabListContent.querySelector('picture');
 
     // init tablist

--- a/blocks/testimonials/testimonials.js
+++ b/blocks/testimonials/testimonials.js
@@ -91,7 +91,7 @@ export default function decorate(block) {
 
   rows.forEach((row, index) => {
     const tabListContent = row.querySelector(':scope > div:first-child');
-    const tabListTitle = tabListContent.querySelector('p:not(:empty):not(:has(picture)');
+    const tabListTitle = tabListContent.querySelector('p:not(:empty):not(:has(picture))');
     const tabListImage = tabListContent.querySelector('picture');
 
     // init tablist


### PR DESCRIPTION
Some SVG logos would not load in Firefox. The root cause was an unterminated CSS select expression that Chrome ignored, but Firefox failed with. This fix closes the bracket

See https://svg-fix--helix-website--adobe.hlx.live/home

Kudos to @stefanseifert for reporting the issue