### PR TITLE
[#329] Performance fix: doc detail page

### DIFF
--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -1,19 +1,21 @@
 .breadcrumb-wrapper {
   display: none;
   width: 100%;
+  max-height: var(--breadcrumb-height);
   background: var(--color-white);
   box-shadow: 0 4px 6px rgba(0 0 0 / 15%);
   z-index: 100;
 }
 
 .breadcrumb-wrapper:not(.no-shadow) {
-  box-shadow: 0 4px 6px rgba(0 0 0 15%);
   margin-bottom: var(--spacing-xxs);
 }
 
-.block.breadcrumb {
+.breadcrumb {
   max-width: var(--header-container-width);
   padding: 0 var(--header-container-tablet-x-padding);
+  height: var(--breadcrumb-height);
+  overflow: hidden; 
 }
 
 .breadcrumb ul {

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -40,13 +40,25 @@ const youtube = (element) => {
   element.parentElement.remove();
 };
 
+const initObserver = (callback) => new IntersectionObserver((entries) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting) {
+      callback(entry.target);
+    }
+  });
+}, { root: null, rootMargin: '200px', threshold: 0 });
+
 export default function decorate(block) {
   const a = block.querySelector('a');
   const { hostname } = new URL(a.href);
   if (hostname.includes('youtu')) {
-    youtube(a);
+    initObserver(() => {
+      youtube(a);
+    }).observe(a);
   }
   if (hostname.includes('gist')) {
-    gist(a);
+    initObserver(() => {
+      gist(a);
+    }).observe(a);
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -377,13 +377,6 @@ h6 strong {
 }
 
 /* Heading XXL */
-h1 u {
-  font-size: 45px;
-  line-height: 1.3;
-  text-decoration: none;
-}
-
-/* Heading XXL */
 h1 {
   font-size: var(--type-heading-xxl-size);
   line-height: 1;
@@ -400,18 +393,6 @@ h2 {
 h3 {
   font-size: var(--type-heading-m-size);
   line-height: var(--type-heading-m-lh);
-}
-
-@media (min-width: 900px) {
-  /* Heading XXL */
-  h1 u {
-    font-size: 60px;
-  }
-}
-
-/* Themes */
-.dark {
-  color: white;
 }
 
 /* Utilities */
@@ -436,10 +417,6 @@ em a {
 /* Primary button over background */
 strong a {
   color: inherit;
-}
-
-.dark em a {
-  color: #fff;
 }
 
 pre {
@@ -656,52 +633,6 @@ a.button.reverse.primary-cta:any-link:hover {
 a.button.reverse.accent:any-link:active,
 a.button.reverse.primary-cta:any-link:active {
   background-color: var(--color-info-accent-reverse-down);
-}
-
-a.button.dark:any-link {
-  color: var(--color-black);
-  background-color: var(--color-white);
-  border-color: var(--color-white);
-}
-
-a.button.dark:any-link:hover {
-  color: var(--color-black);
-  background-color: var(--color-gray-100);
-  border-color: var(--color-gray-100);
-}
-
-a.button.dark:any-link:active {
-  color: var(--color-black);
-  background-color: var(--color-gray-200);
-  border-color: var(--color-gray-200);
-}
-
-a.button.dark:any-link:focus {
-  box-shadow: 0 0 0 2px var(--color-info-accent), 0 0 0 4px var(--color-white);
-}
-
-a.button.dark.reverse:any-link {
-  color: var(--color-white);
-  background-color: transparent;
-  border-color: var(--color-white);
-}
-
-a.button.dark.reverse:any-link:hover {
-  color: var(--color-white);
-  background-color: rgb(0 0 0 / 10%);
-  border-color: var(--color-gray-100);
-}
-
-a.button.dark.reverse:any-link:active {
-  color: var(--color-white);
-  background-color: rgb(0 0 0 / 20%);
-  border-color: var(--color-gray-200);
-}
-
-a.button.dark.reverse:any-link:focus {
-  background-color: var(--color-white);
-  border-color: var(--color-white);
-  color: var(--color-info-accent-hover);
 }
 
 a.button > svg {
@@ -1428,22 +1359,6 @@ body.no-header-template {
   transform: none;
 }
 
-/* clip-path */
-.clip-path-reveal {
-  transition: var(--fade-transition);
-  clip-path: inset(0 100% 0 0);
-}
-
-.clip-path-reveal-short {
-  transition: clip-path 0.25s ease-in-out;
-  clip-path: inset(0 100% 0 0);
-}
-
-.in-view .clip-path-reveal,
-.in-view .clip-path-reveal-short {
-  clip-path: inset(0 0 0 0);
-}
-
 /* animation: text fade & scale down */
 .text-main-reveal {
   color: var(--color-black);
@@ -1758,8 +1673,7 @@ body.guides-template .form {
   margin: var(--spacing-s) 0 var(--spacing-l);
 }
 
-/* for guides-template without hero section (.heading), like documentation detail page */
-
+/* for guides-template without hero section (.heading), like doc detail page */
 body.guides-template main.without-full-width-hero .default-content-wrapper h1 {
   margin-top: var(--spacing-s);
 }
@@ -1784,8 +1698,7 @@ body.guides-template main.without-full-width-hero .default-content-wrapper img {
   margin: var(--spacing-s) auto var(--spacing-xs);
 }
 
-/* for guides-template with hero section (.heading), like documentation category page */
-
+/* for guides-template with hero section (.heading), like doc category page */
 body.guides-template main.has-full-width-hero .section.heading {
   padding-bottom: var(--spacing-xs);
 }


### PR DESCRIPTION
Reported Issue:
- 0.247 CLS with 86 mobile lighthouse score reported in this doc detail page
https://pagespeed.web.dev/analysis/https-www-hlx-live-docs-sidekick/rc88p931o4?form_factor=mobile

Updates in current PR:
- update `embed.js` to use intersectionObserver for rendering youtube & gist block
- fixed height in breadcrumb to prevent layout shift
- cleanup unused css

Test Urls:
Before: https://main--helix-website--adobe.hlx.page/docs/sidekick
After: https://redesign-doc-page-perf-fix--helix-website--adobe.hlx.live/docs/sidekick