### PR TITLE
[360] Use submit event for form submission

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -49,13 +49,12 @@ async function submitForm(form) {
   return payload;
 }
 
-function createButton(fd) {
+function createButton(fd, form = '') {
   const button = document.createElement('button');
   button.textContent = fd.Label;
   button.classList.add('button');
-  if (fd.Type === 'submit') {
-    button.addEventListener('click', async (event) => {
-      const form = button.closest('form');
+  if (fd.Type === 'submit' && form) {
+    form.addEventListener('submit', async (event) => {
       if (fd.Placeholder) form.dataset.action = fd.Placeholder;
       if (form.checkValidity()) {
         event.preventDefault();
@@ -166,7 +165,7 @@ async function createForm(formURL) {
         fieldWrapper.append(createTextArea(fd));
         break;
       case 'submit':
-        fieldWrapper.append(createButton(fd));
+        fieldWrapper.append(createButton(fd, form));
         break;
       default:
         fieldWrapper.append(createLabel(fd));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Form block uses 
<!--- Describe your changes in detail -->

## Related Issue
#360 

## Motivation and Context
Forms are submitted by a listener on the click event of the submit button. The payload is generated and POST'ed as a json via fetch API. This prevents the triggering of the submit event.

This behaviour prevents other features such as RUM or Conversion tracking to work automatically, as they listen to submit events

## How Has This Been Tested?
* Run the project locally.
* On chrome browser open: https://www.hlx.live/developer/forms
* Open developer tools -> Console and add a submit listener on the form element. `document.getElementsByTagName('form')[0].addEventListener('submit', (e) => {console.log('form submitted');})`
* Scroll down to the sample form in the page, enter some data and click submit button.
* Validate that in the browser Console, there is a message `form submitted`
* Check that POST fetch request is still sent
* Check that redirection after submit is still happening

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
