### PR TITLE
fix(table): don't uppercase the first row if there is a header row

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -45,3 +45,7 @@ body main .table td p {
   padding-bottom: var(--spacing-xxs);
   color: var(--color-black);
 }
+
+.table thead + tbody tr:first-of-type td {
+  text-transform: none;
+}


### PR DESCRIPTION
We found this issue during the support training today :)

See https://table--helix-website--adobe.hlx.live/developer/indexing#setting-up-properties-to-be-added-to-the-index (scroll to the first table)

and compare it to https://main--helix-website--adobe.hlx.live/developer/indexing#setting-up-properties-to-be-added-to-the-index