### PR TITLE
Streamline header and footer loading with boilerplate standard.

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,4 +1,4 @@
-import { readBlockConfig } from '../../scripts/lib-franklin.js';
+import { getMetadata } from '../../scripts/lib-franklin.js';
 import createTag from '../../utils/tag.js';
 import { returnLinkTarget } from '../../utils/helpers.js';
 
@@ -116,11 +116,12 @@ const decoratefooterCopyrightSection = (footer) => {
  */
 
 export default async function decorate(block) {
-  const cfg = readBlockConfig(block);
+  const footerMeta = getMetadata('footer');
   block.textContent = '';
   block.classList.add('contained');
 
-  const footerPath = cfg.footer || '/new-footer';
+  // load footer fragment
+  const footerPath = footerMeta.footer || '/footer';
   const resp = await fetch(`${footerPath}.plain.html`);
   const html = await resp.text();
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -511,9 +511,9 @@ async function fetchGnav(url) {
 }
 
 export default async function init(blockEl) {
-  // OLD CODE: const url = getMetadata('gnav') || '/gnav';
-  const url = '/new-nav';
-  const html = await fetchGnav(url);
+  const navMeta = getMetadata('nav');
+  const navPath = navMeta ? new URL(navMeta).pathname : '/nav';
+  const html = await fetchGnav(navPath);
 
   if (html) {
     try {


### PR DESCRIPTION
Remove temporary "new-" prefixes and added the loading from metadata from the boilerplate.

## Motivation and Context

Helix 5 Workshop.

## How Has This Been Tested?

Locally and on branch URL.

 - Before: https://main--www-aem-live--adobe.hlx.live/home
 - After: https://streamline-header-footer--www-aem-live--adobe.hlx.live/home

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
