### PR TITLE
chore: remove sitemap config

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,5 +1,0 @@
-sitemaps:
-   example:
-     origin: https://www.aem.live
-     source: /query-index.json
-     destination: /sitemap.xml


### PR DESCRIPTION
https://configless-sitemap--helix-website--adobe.aem.page/home

vs. 

https://main--helix-website--adobe.aem.page/home