### PR TITLE
Widescreen display of Docs with Search Results

### DIFF
--- a/blocks/side-navigation/side-navigation.css
+++ b/blocks/side-navigation/side-navigation.css
@@ -534,4 +534,9 @@
   .side-navigation-wrapper > div {
     max-width: var(--grid-desktop-container-width);
   }
+
+  .side-navigation-wrapper.expand + .section.content {
+    margin-left: 16%;
+    margin-right: 16%;
+  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -324,6 +324,7 @@ aside {
   .default-content-wrapper,
   .contained-wrapper,
   .side-navigation-wrapper.expand,
+  .side-navigation-wrapper.expand + .section.content,
   .franklin .gnav .submenu-content {
     max-width: var(--grid-desktop-container-width);
   }
@@ -2014,7 +2015,7 @@ body.contact-template main .default-content-wrapper img {
   max-width: var(--header-container-width);
   padding: 0 var(--header-container-tablet-x-padding);
   height: var(--breadcrumb-height);
-  overflow: hidden; 
+  overflow: hidden;
   margin: auto;
 }
 


### PR DESCRIPTION
## Description
When search results are displayed on the docs page with a widescreen, the layout was off balance.
I adjusted the CSS for widescreen display in this situation.

## Related Issue
Fix #471 

## Motivation and Context
User experience

## How Has This Been Tested?
CSS change only.

Test URLs:

- Before: https://main--helix-website--adobe.aem.live/docs/?q=font
- After: https://471-docs-widescreen--helix-website--adobe.aem.live/docs/?q=font

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
