### PR TITLE
feat: remove softnav and use prerender

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -11,15 +11,17 @@ const preloaded = new Set();
 async function preloadPage(href) {
   const hrefURL = new URL(href);
   if (hrefURL.origin === window.location.origin) {
-    const resp = await fetch(href);
-    const html = await resp.text();
-    const dom = new DOMParser().parseFromString(html, 'text/html');
-    const picture = dom.querySelector('picture');
-    if (picture) {
-      const imgLoader = document.createElement('div');
-      imgLoader.append(picture);
-      picture.querySelector('img').loading = 'eager';
-    }
+    // use speculation rules to preload the page
+    const script = document.createElement('script');
+    script.type = 'speculationrules';
+    script.textContent = JSON.stringify({
+      prerender: [
+        {
+          urls: [`${hrefURL.pathname}${hrefURL.search}`],
+        },
+      ],
+    });
+    document.head.appendChild(script);
   }
 }
 


### PR DESCRIPTION
Use prerender instruction https://developer.chrome.com/docs/web-platform/prerender-pages when mouse approaching a link and remove the softnav, i.e. do a classic navigation while target page has been prerendered.

Before: https://main--helix-website--adobe.aem.page/developer/tutorial
After: https://prerender--helix-website--adobe.aem.page/developer/tutorial