### PR TITLE
fix(rum-explorer): assign equal weight to each CWV metric in bundle when assiging overall bundle value

### DIFF
--- a/tools/rum/cwvtimeline.js
+++ b/tools/rum/cwvtimeline.js
@@ -2,7 +2,7 @@
  * Implements the CWV timeline chart (currently the only chart in the RUM explorer)
  */
 import {
-  scoreBundle, scoreCWV, toHumanReadable, truncate,
+  scoreCWV, toHumanReadable, truncate, weighBundle,
 } from './utils.js';
 
 const INTERPOLATION_THRESHOLD = 10;
@@ -223,10 +223,10 @@ export default class CWVTimeLineChart {
       dataChunks.addSeries('niCWV', (bundle) => (scoreCWV(bundle.cwvINP, 'inp') === 'ni' ? bundle.weight : undefined));
       dataChunks.addSeries('noCWV', () => (0));
     } else {
-      dataChunks.addSeries('goodCWV', (bundle) => (scoreBundle(bundle) === 'good' ? bundle.weight : undefined));
-      dataChunks.addSeries('poorCWV', (bundle) => (scoreBundle(bundle) === 'poor' ? bundle.weight : undefined));
-      dataChunks.addSeries('niCWV', (bundle) => (scoreBundle(bundle) === 'ni' ? bundle.weight : undefined));
-      dataChunks.addSeries('noCWV', (bundle) => (scoreBundle(bundle) === null ? bundle.weight : undefined));
+      dataChunks.addSeries('goodCWV', (bundle) => weighBundle(bundle).good);
+      dataChunks.addSeries('poorCWV', (bundle) => weighBundle(bundle).poor);
+      dataChunks.addSeries('niCWV', (bundle) => weighBundle(bundle).ni);
+      dataChunks.addSeries('noCWV', (bundle) => weighBundle(bundle).no);
     }
 
     // interpolated series

--- a/tools/rum/test/utils.test.js
+++ b/tools/rum/test/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { truncate } from '../utils.js';
+import { truncate, weighBundle } from '../utils.js';
 
 describe('truncate', () => {
   it('truncates to the beginning of the hour', () => {
@@ -36,5 +36,123 @@ describe('truncate', () => {
   it('truncates to the beginning of the week (May 14th)', () => {
     const time = new Date('2024-05-14T00:00:00+02:00');
     assert.strictEqual(truncate(time, 'week'), '2024-05-12T00:00:00+02:00');
+  });
+});
+
+describe('weighBundle', () => {
+  it('weighs a bundle with a single CWV', () => {
+    const bundle = {
+      id: 'mv',
+      host: 'www.aem.live',
+      time: '2024-05-01T03:13:27.389Z',
+      timeSlot: '2024-05-01T03:00:00.000Z',
+      url: 'https://www.aem.live/docs/setup-byo-cdn-push-invalidation',
+      userAgent: 'desktop:mac',
+      weight: 100,
+      events: [
+        {
+          checkpoint: 'cwv-inp',
+          value: 8,
+          timeDelta: 807389.1000976,
+        },
+      ],
+      cwvINP: 8,
+    };
+    const weights = weighBundle(bundle);
+    assert.deepEqual(weights, {
+      goodINP: 100,
+      good: 100,
+    });
+  });
+
+  it('weighs a bundle with two CWVs', () => {
+    const bundle = {
+      id: 'mv',
+      host: 'www.aem.live',
+      time: '2024-05-01T03:13:27.389Z',
+      timeSlot: '2024-05-01T03:00:00.000Z',
+      url: 'https://www.aem.live/docs/setup-byo-cdn-push-invalidation',
+      userAgent: 'desktop:mac',
+      weight: 100,
+      events: [
+        {
+          checkpoint: 'cwv-inp',
+          value: 8,
+          timeDelta: 807389.1000976,
+        },
+        {
+          checkpoint: 'cwv-lcp',
+          value: 4000,
+          timeDelta: 807389.1000976,
+        },
+      ],
+      cwvINP: 8,
+      cwvLCP: 4000,
+    };
+    const weights = weighBundle(bundle);
+    assert.deepEqual(weights, {
+      goodINP: 50,
+      poorLCP: 50,
+      good: 50,
+      poor: 50,
+    });
+  });
+
+  it('weighs a bundle with three CWVs', () => {
+    const bundle = {
+      id: 'mv',
+      host: 'www.aem.live',
+      time: '2024-05-01T03:13:27.389Z',
+      timeSlot: '2024-05-01T03:00:00.000Z',
+      url: 'https://www.aem.live/docs/setup-byo-cdn-push-invalidation',
+      userAgent: 'desktop:mac',
+      weight: 100,
+      events: [
+        {
+          checkpoint: 'cwv-inp',
+          value: 8,
+          timeDelta: 807389.1000976,
+        },
+        {
+          checkpoint: 'cwv-lcp',
+          value: 4000,
+          timeDelta: 807389.1000976,
+        },
+        {
+          checkpoint: 'cwv-cls',
+          value: 0.1,
+          timeDelta: 807389.1000976,
+        },
+      ],
+      cwvINP: 8,
+      cwvLCP: 4000,
+      cwvCLS: 0.1,
+    };
+    const weights = weighBundle(bundle);
+    assert.deepEqual(weights, {
+      goodINP: 33,
+      poorLCP: 33,
+      niCLS: 33,
+      good: 33,
+      poor: 33,
+      ni: 33,
+    });
+  });
+
+  it('weighs a bundle with no CWVs', () => {
+    const bundle = {
+      id: 'mv',
+      host: 'www.aem.live',
+      time: '2024-05-01T03:13:27.389Z',
+      timeSlot: '2024-05-01T03:00:00.000Z',
+      url: 'https://www.aem.live/docs/setup-byo-cdn-push-invalidation',
+      userAgent: 'desktop:mac',
+      weight: 100,
+      events: [],
+    };
+    const weights = weighBundle(bundle);
+    assert.deepEqual(weights, {
+      no: 100,
+    });
   });
 });

--- a/tools/rum/utils.js
+++ b/tools/rum/utils.js
@@ -50,19 +50,18 @@ export function toHumanReadable(num) {
 
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}${getTimezoneOffset()}`;
 }
-export function scoreBundle(bundle) {
-  // a bundle is good if all CWV that have a value are good
-  // a bundle is ni if all CWV that have a value are ni or good
-  // a bundle is poor if any CWV that have a value are poor
-  // a bundle has no CWV if no CWV have a value
+
+export function weighBundle(bundle) {
   const cwv = ['cwvLCP', 'cwvCLS', 'cwvINP'];
   const scores = cwv
     .filter((metric) => bundle[metric])
-    .map((metric) => scoreCWV(bundle[metric], metric.toLowerCase().slice(3)));
-  if (scores.length === 0) return null;
-  if (scores.every((s) => s === 'good')) return 'good';
-  if (scores.every((s) => s !== 'poor')) return 'ni';
-  return 'poor';
+    .map((metric) => ([metric.slice(3), scoreCWV(bundle[metric], metric.toLowerCase().slice(3))]));
+  if (scores.length === 0) return { no: bundle.weight };
+  return scores.reduce((acc, [metric, score]) => {
+    acc[score + metric] = Math.floor(bundle.weight / scores.length);
+    acc[score] = (acc[score] || 0) + Math.floor(bundle.weight / scores.length);
+    return acc;
+  }, {});
 }
 
 export function truncate(time, unit) {


### PR DESCRIPTION
in the past, we would use the lowest possible consensus of all available CWV metrics, which would
lead to scores look worse in aggregate than comparing each of the individual scores would imply.
This change gives each present score an equal weight, so that the pre-refactoring behavior has been
restored and aggregate metrics look a bit more favorable

see https://cq-dev.slack.com/archives/C07198KKQ07/p1716223820237169
