### PR TITLE
fix(rum-explorer): empty entries in source or target

### DIFF
--- a/tools/rum/facetsidebar.js
+++ b/tools/rum/facetsidebar.js
@@ -1,5 +1,5 @@
 import { pValue } from './cruncher.js';
-import { toHumanReadable, scoreCWV } from './utils.js';
+import { toHumanReadable, scoreCWV, escapeHTML } from './utils.js';
 
 const facetDecorators = {
   userAgent: {
@@ -101,7 +101,7 @@ export default class FacetSidebar {
       if (usePlaceholders && placeholders[labelText]) {
         return (`${placeholders[labelText]} [${labelText}]`);
       }
-      return (labelText);
+      return escapeHTML(labelText);
     };
 
     const numOptions = mode === 'all' ? 20 : 10;

--- a/tools/rum/test/utils.test.js
+++ b/tools/rum/test/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { truncate } from '../utils.js';
+import { truncate, escapeHTML } from '../utils.js';
 
 describe('truncate', () => {
   it('truncates to the beginning of the hour', () => {
@@ -36,5 +36,13 @@ describe('truncate', () => {
   it('truncates to the beginning of the week (May 14th)', () => {
     const time = new Date('2024-05-14T00:00:00+02:00');
     assert.strictEqual(truncate(time, 'week'), '2024-05-12T00:00:00+02:00');
+  });
+});
+
+describe('escapeHTML', () => {
+  it('escapes HTML entities', () => {
+    assert.strictEqual(escapeHTML('<script>alert("xss")</script>'), '&#60;script&#62;alert(&#34;xss&#34;)&#60;/script&#62;');
+    assert.strictEqual(escapeHTML("<script>alert('xss')</script>"), '&#60;script&#62;alert(&#39;xss&#39;)&#60;/script&#62;');
+    assert.strictEqual(escapeHTML('<div>hello</div>'), '&#60;div&#62;hello&#60;/div&#62;');
   });
 });

--- a/tools/rum/utils.js
+++ b/tools/rum/utils.js
@@ -78,3 +78,7 @@ export function truncate(time, unit) {
   if (unit === 'month') t.setDate(1);
   return toISOStringWithTimezone(t);
 }
+
+export function escapeHTML(text) {
+  return text.replace(/[&<>"']/g, c => `&#${c.charCodeAt(0)};`);
+}

--- a/tools/rum/utils.js
+++ b/tools/rum/utils.js
@@ -79,6 +79,6 @@ export function truncate(time, unit) {
   return toISOStringWithTimezone(t);
 }
 
-export function escapeHTML(text) {
-  return text.replace(/[&<>"']/g, c => `&#${c.charCodeAt(0)};`);
+export function escapeHTML(unsafe) {
+  return unsafe.replace(/[&<>"']/g, c => `&#${c.charCodeAt(0)};`);
 }


### PR DESCRIPTION
We now track LCP source and target. In some cases, no id or url can be determined thus we store the first character of the element outer HTML (might element determining what is the element). Problem: the HTML is not escaped and set as data attribute which corrupt the DOM.

Before:
- https://www.aem.live/tools/rum/explorer.html?domain=www.aem.live&filter=&view=week&metrics=all&checkpoint=cwv-lcp&domainkey=53A02890-F91F-428B-A870-A809B82D953E
- `cwv-source` facet contains empty entries

After:
- https://escape-html--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=www.aem.live&filter=&view=week&metrics=all&checkpoint=cwv-lcp&domainkey=53A02890-F91F-428B-A870-A809B82D953E
- `cwv-source` facet contains html elements

Note: the escaping is added to all facets and might slow down the rendering. Probably non significantly. If needed and for performance improvements, we could escape only the source and target, not all facets.