### PR TITLE
feat(rum-explorer): isolate tsv computation

### DIFF
--- a/tools/rum/facetsidebar.js
+++ b/tools/rum/facetsidebar.js
@@ -115,6 +115,50 @@ export default class FacetSidebar {
     }
   }
 
+  computeTSV(facetName, mode, placeholders, show = {}, numOptions = 10) {
+    const facetEntries = this.dataChunks.facets[facetName];
+    const tsv = [];
+    const optionKeys = facetEntries.map((f) => f.value);
+    if (optionKeys.length) {
+      tsv.push(`${facetName}\tcount\tlcp\tcls\tinp`);
+      const filterKeys = facetName === 'checkpoint' && mode !== 'all';
+      const filteredKeys = filterKeys
+        ? optionKeys.filter((a) => !!(placeholders[a]))
+        : optionKeys;
+      const nbToShow = show[facetName] || numOptions;
+      facetEntries
+        .filter((entry) => !filterKeys || filteredKeys.includes(entry.value))
+        .slice(0, nbToShow)
+        .forEach((entry) => {
+          const CWVDISPLAYTHRESHOLD = 10;
+          let lcp = '-';
+          if (entry.metrics.lcp && entry.metrics.lcp.count >= CWVDISPLAYTHRESHOLD) {
+            const lcpValue = entry.metrics.lcp.percentile(75);
+            lcp = `${toHumanReadable(lcpValue / 1000)} s`;
+          }
+
+          let cls = '-';
+          if (entry.metrics.cls && entry.metrics.cls.count >= CWVDISPLAYTHRESHOLD) {
+            const clsValue = entry.metrics.cls.percentile(75);
+            cls = `${toHumanReadable(clsValue)}`;
+          }
+
+          let inp = '-';
+          if (entry.metrics.inp && entry.metrics.inp.count >= CWVDISPLAYTHRESHOLD) {
+            const inpValue = entry.metrics.inp.percentile(75);
+            inp = `${toHumanReadable(inpValue / 1000)} s`;
+          }
+
+          tsv.push(`${entry.name}\t${entry.value}\t${lcp}\t${cls}\t${inp}`);
+        });
+      tsv.push(...facetEntries
+        .filter((entry) => !filterKeys || filteredKeys.includes(entry.value))
+        .slice(0, nbToShow)
+        .map((entry) => `${entry.value}\t${entry.metrics.pageViews.sum}\t${entry.metrics.lcp.percentile(75)}\t${entry.metrics.cls.percentile(75)}\t${entry.metrics.inp.percentile(75)}`));
+    }
+    return tsv;
+  }
+
   updateFacets(focus, mode, placeholders, show = {}) {
     const createLabelHTML = (labelText, usePlaceholders) => {
       if (labelText.startsWith('https://') && labelText.includes('media_')) {
@@ -155,7 +199,6 @@ export default class FacetSidebar {
       const facetEntries = this.dataChunks.facets[facetName];
       const optionKeys = facetEntries.map((f) => f.value);
       if (optionKeys.length) {
-        let tsv = '';
         const fieldSet = document.createElement('fieldset');
         fieldSet.classList.add(`facet-${facetName}`);
         const legend = document.createElement('legend');
@@ -194,7 +237,6 @@ export default class FacetSidebar {
         }
 
         fieldSet.append(legend);
-        tsv += `${facetName}\tcount\tlcp\tcls\tinp\r\n`;
         const filterKeys = facetName === 'checkpoint' && mode !== 'all';
         const filteredKeys = filterKeys
           ? optionKeys.filter((a) => !!(placeholders[a]))
@@ -284,20 +326,10 @@ export default class FacetSidebar {
             inpLI.classList.add(`score-${inpScore}`);
             inpLI.textContent = inp;
             ul.append(inpLI);
-            tsv += `${entry.name}\t${entry.value}\t${lcp}\t${cls}\t${inp}\r\n`;
 
             div.append(input, label, ul);
             fieldSet.append(div);
           });
-        // populate pastebuffer with overflow data
-        // ideally, this would be populated only when
-        // the user clicks the copy button, so that we
-        // don't waste cycles on rendering p75s that
-        // the user never sees.
-        tsv = facetEntries
-          .filter((entry) => !filterKeys || filteredKeys.includes(entry.value))
-          .slice(0, nbToShow)
-          .reduce((acc, entry) => `${acc}${entry.value}\t${entry.metrics.pageViews.sum}\t${entry.metrics.lcp.percentile(75)}\t${entry.metrics.cls.percentile(75)}\t${entry.metrics.inp.percentile(75)}\r\n`, tsv);
 
         if (filteredKeys.length > nbToShow) {
           // add "more" link
@@ -338,7 +370,8 @@ export default class FacetSidebar {
         }
 
         legend.addEventListener('click', () => {
-          navigator.clipboard.writeText(tsv);
+          const tsv = this.computeTSV(facetName, mode, placeholders, show, numOptions);
+          navigator.clipboard.writeText(tsv.join('\r\n'));
           const toast = document.getElementById('copied-toast');
           toast.ariaHidden = false;
           setTimeout(() => { toast.ariaHidden = true; }, 3000);


### PR DESCRIPTION
Before:

- https://www.aem.live/tools/rum/explorer.html?domain=www.adobe.com&filter=&view=year&checkpoint=click&domainkey=9A3B022A-4C58-4060-A76E-04DD0E70F1D0
- full ui updated in 388ms

After

- https://explorer-tsv--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=www.adobe.com&filter=&view=year&checkpoint=click&domainkey=9A3B022A-4C58-4060-A76E-04DD0E70F1D0
- full ui updated in 378ms

While gain on rendering speed is minimum, we save a lot of memory not computing some large strings (only needed if someone hits the copy button).

There are certainly ways to not recompute everything, just reading the values... For now, it is ok as is.