### PR TITLE
feat: feed block for community feed

### DIFF
--- a/blocks/feed/feed.css
+++ b/blocks/feed/feed.css
@@ -1,0 +1,129 @@
+.feed.recent {
+  text-align: left;
+}
+
+.feed.recent .feed-item img {
+  max-width: 100%;
+  filter: var(--image-filter-drop-shadow-small);
+  width: 100%;
+  aspect-ratio: 5 / 4;
+  object-fit: contain;
+}
+
+.feed.recent > div {
+  margin-bottom: var(--spacing-s);
+  padding: var(--spacing-ml) 0;
+  gap: var(--spacing-s);
+}
+
+.feed.recent > div > div {
+  margin: 0 auto;
+  padding: var(--spacing-s) 0;
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+.feed.recent > div > div > div {
+  padding: var(--spacing-xl) var(--spacing-ml) var(--spacing-m);
+  background: var(--bg-color-lightgrey);
+  border-radius: var(--card-border-radius-l);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+}
+
+.feed.recent .feed-item .image-wrapper-el {
+  margin-top: auto;
+  padding-top: var(--spacing-s);
+}
+
+.feed.recent h3 {
+  margin-bottom: var(--spacing-xs);
+  font-size: var(--type-heading-xl-size);
+  line-height: var(--type-heading-xl-lh);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.feed.recent p {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+}
+
+@media screen and (min-width: 768px) {
+  .feed.recent > div > div {
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-gap: var(--spacing-xs);
+  }
+
+  .feed.recent > div > div > div {
+    padding: var(--spacing-xl) var(--spacing-s) var(--spacing-m);
+    text-align: left;
+  }
+
+  .feed.recent h3 {
+    font-size: var(--type-heading-s-size);
+    line-height: var(--type-heading-s-lh);
+  }
+
+  .feed.recent p {
+    font-size: var(--type-body-xs-size);
+    line-height: var(--type-body-xs-lh);
+    margin-bottom: 1em;
+  }
+}
+
+@media screen and (min-width: 900px) {
+  .feed.recent > div {
+    margin-bottom: 0;
+    flex-direction: column;
+    max-width: var(--grid-desktop-container-width);
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-gap: var(--spacing-m);
+    padding: var(--spacing-xs) 0;
+  }
+
+  .feed.recent h3 {
+    margin-bottom: var(--spacing-s);
+    font-size: var(--type-heading-m-size);
+    line-height: var(--type-heading-m-lh);
+  }
+
+  .feed.recent .image-wrapper-el {
+    padding-top: var(--spacing-l);
+    margin-bottom: 0;
+  }
+
+  .feed.recent > div > div {
+    grid-gap: 32px;
+  }
+
+  .feed.recent > div > div > div{
+    padding: var(--spacing-xl) var(--spacing-m);
+    margin-bottom: var(--spacing-s);
+  }
+
+  /* force image to stick to bottom */
+  .feed.recent > p {
+    flex: 1;
+    font-size: var(--type-body-m-size);
+    line-height: var(--type-body-s-lh);
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .feed.recent h3 {
+    font-size: var(--type-heading-l-size);
+    line-height: var(--type-heading-l-lh);
+  }
+
+  .feed.recent > div > div > div {
+    padding: var(--spacing-xxl) var(--spacing-xl);
+  }
+
+  .feed.recent p {
+    font-size: var(--type-body-s-size);
+    line-height: var(--type-body-s-lh);
+    margin-bottom: 1em;
+  }
+}

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -1,0 +1,56 @@
+import { createTag } from '../../scripts/scripts.js';
+
+export async function renderFeed(block) {
+  if (!block) {
+    return;
+  }
+  const archivePageIndex = window.siteindex.archive.data;
+  archivePageIndex.reverse();
+  const parentDiv = createTag('div');
+  let gridDiv;
+
+  archivePageIndex.forEach((page, index) => {
+    if (index % 3 === 0) {
+      gridDiv = createTag('div');
+    }
+
+    const div = createTag('div', { class: 'feed-item' });
+
+    const h3 = createTag('h3', { class: 'title' }, page.Title);
+    div.appendChild(h3);
+
+    const desc = createTag('p', { class: 'desc' }, page.Description);
+    div.appendChild(desc);
+
+    const title = createTag('p', { class: 'link' });
+    const a = createTag('a', {
+      href: page.URL, target: '_blank',
+    }, page.Title);
+    title.appendChild(a);
+    div.appendChild(title);
+
+    const image = createTag('p', { class: 'image-wrapper-el' });
+
+    // Extract image id from page.URL
+    const id = page.URL.split('=')[1];
+    const img = createTag('img', { src: `https://img.youtube.com/vi/${id}/0.jpg` });
+    image.appendChild(img);
+    div.appendChild(image);
+
+    gridDiv.appendChild(div);
+    if (index % 3 === 2 || index === archivePageIndex.length - 1) {
+      parentDiv.appendChild(gridDiv);
+    }
+  });
+  block.appendChild(parentDiv);
+}
+
+export default async function decorate(block) {
+  if (window?.siteindex?.loaded) {
+    await renderFeed(block);
+  } else {
+    const div = createTag('div', { class: 'feed-hidden' }, '');
+    block.append(div);
+    document.addEventListener('dataset-ready', () => renderFeed(block));
+  }
+}

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -1,4 +1,7 @@
-import { createTag } from '../../scripts/scripts.js';
+import {
+  createTag,
+  loadFeedData,
+} from '../../scripts/scripts.js';
 
 export async function renderFeed(block) {
   if (!block) {
@@ -46,6 +49,7 @@ export async function renderFeed(block) {
 }
 
 export default async function decorate(block) {
+  loadFeedData();
   if (window?.siteindex?.loaded) {
     await renderFeed(block);
   } else {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -579,6 +579,24 @@ export function buildAutoBlocks(main) {
   }
 }
 
+function loadFeedData() {
+  window.siteindex = window.siteindex || { archive: { data: [] }, loaded: false };
+  const offset = 0;
+
+  fetch(`/drafts/asthabharga/community-feeds.json?offset=${offset}`)
+    .then((response) => response.json())
+    .then((responseJson) => {
+      window.siteindex.archive.data = responseJson?.archive?.data;
+      window.siteindex.loaded = true;
+      const event = new Event('dataset-ready');
+      document.dispatchEvent(event);
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.log(`Error loading query index: ${error.message}`);
+    });
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -709,6 +727,7 @@ function loadDelayed() {
  * Decorates the page.
  */
 async function loadPage(doc) {
+  loadFeedData();
   await window.hlx.plugins.load('eager');
   await loadEager(doc);
   await window.hlx.plugins.load('lazy');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -583,7 +583,7 @@ function loadFeedData() {
   window.siteindex = window.siteindex || { archive: { data: [] }, loaded: false };
   const offset = 0;
 
-  fetch(`/drafts/asthabharga/community-feeds.json?offset=${offset}`)
+  fetch(`/community-feeds.json?offset=${offset}`)
     .then((response) => response.json())
     .then((responseJson) => {
       window.siteindex.archive.data = responseJson?.archive?.data;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -579,7 +579,7 @@ export function buildAutoBlocks(main) {
   }
 }
 
-function loadFeedData() {
+export function loadFeedData() {
   window.siteindex = window.siteindex || { archive: { data: [] }, loaded: false };
   const offset = 0;
 
@@ -727,7 +727,6 @@ function loadDelayed() {
  * Decorates the page.
  */
 async function loadPage(doc) {
-  loadFeedData();
   await window.hlx.plugins.load('eager');
   await loadEager(doc);
   await window.hlx.plugins.load('lazy');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -273,7 +273,8 @@ body.appear {
 .block.contained,
 .section.content > div,
 .default-content-wrapper,
-.contained-wrapper {
+.contained-wrapper,
+.feed.recent {
   max-width: var(--grid-mobile-container-width);
   margin-left: auto;
   margin-right: auto;
@@ -288,7 +289,8 @@ aside {
   .block.contained,
   .section.content > div,
   .default-content-wrapper,
-  .contained-wrapper {
+  .contained-wrapper,
+  .feed.recent {
     max-width: var(--grid-tablet-container-width);
   }
 }
@@ -297,7 +299,8 @@ aside {
   .block.contained,
   .default-content-wrapper,
   .franklin .gnav .submenu-content,
-  .contained-wrapper {
+  .contained-wrapper,
+  .feed.recent {
     max-width: 90%;
   }
 
@@ -325,7 +328,8 @@ aside {
   .contained-wrapper,
   .side-navigation-wrapper.expand,
   .side-navigation-wrapper.expand + .section.content,
-  .franklin .gnav .submenu-content {
+  .franklin .gnav .submenu-content,
+  .feed.recent {
     max-width: var(--grid-desktop-container-width);
   }
 


### PR DESCRIPTION
## Description
Currently the details of discord events (Recent recordings) are added manually on community page. This PR introduces a new block (Feed block) which dynamically fetches these details from community-feed.json (once the event is complete and its details are published there). 

## Related Issue
Fix for #536 

## Motivation and Context
No more manual intervention required to update event/recording details once they are completed. It just requires discord event to be created on calendar and rest of the workflow to update the details is handled.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

https://main--helix-website--adobe.aem.page/drafts/asthabharga/community
vs
https://issue-536--helix-website--adobe.aem.page/drafts/asthabharga/community