### PR TITLE
feature: add tooltips to key metrics

### DIFF
--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -262,34 +262,34 @@ const io = new IntersectionObserver((entries) => {
 </div>
 <div class="key-metrics">
   <ul>
-    <li id="pageviews">
-      <h2>Pageviews</h2>
+    <li id="pageviews" title="Estimate of page views based on RUM data collected and sampling rate">
+      <h2>Page views</h2>
       <p>0</p>
     </li>
-    <li id="visits">
+    <li id="visits" title="Page views which were not linked from another page on this site">
       <h2>Visits</h2>
       <p>0</p>
     </li>
-    <li id="conversions">
+    <li id="conversions" title="Page views with a user click">
       <h2>Conversions</h2>
       <p>0</p>
     </li>
-    <li id="lcp">
+    <li id="lcp" title="Largest Contentful Paint">
       <h2>LCP</h2>
       <p>0</p>
     </li>
-    <li id="cls">
+    <li id="cls" title="Cumulative Layout Shift">
       <h2>CLS</h2>
       <p>0</p>
     </li>
-    <li id="inp">
+    <li id="inp" title="Interaction to Next Paint">
       <h2>INP</h2>
       <p>0</p>
     </li>
   </ul>
   <div class="key-metrics-more" aria-hidden="true">
     <ul>
-      <li id="ttfb">
+      <li id="ttfb" title="Time to First Byte">
         <h2>TTFB</h2>
         <p>0</p>
       </li>  


### PR DESCRIPTION
## Description

Added tooltips to the key metrics at the top of the page, and changed "Pageviews" to "Page views".

## Related Issue

## Motivation and Context

We get questions periodically about the meaning of some of the key metrics.

## How Has This Been Tested?

https://keymetrics-tooltips--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=emigrationbrewing.com&filter=&view=month&domainkey=open

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
