### PR TITLE
fix: rum form elements inherit font

### DIFF
--- a/tools/rum/elements/facetsidebar.js
+++ b/tools/rum/elements/facetsidebar.js
@@ -69,6 +69,7 @@ export default class FacetSidebar extends HTMLElement {
       .filter((key) => key !== 'filter');
     keys.forEach((facetName) => {
       const facetEl = this.querySelector(`[facet="${facetName}"]`);
+      // eslint-disable-next-line no-console
       console.assert(facetEl, `Facet ${facetName} not found in provided UI elements.`);
 
       if (facetEl) facetEl.setAttribute('mode', mode || 'default');

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -63,21 +63,23 @@ main li.score-poor, vitals-facet div[data-value^="poor"] label {
 }
 
 /* heading */
+main .title div {
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+}
+
 main .title select {
-  border: 1px solid currentcolor;
-  border-radius: 16px;
+  border: 2px solid var(--dark-blue);
+  border-radius: 32px;
+  padding: 2px 15px;
   background-color: var(--dark-blue);
-  padding: 2px 8px;
-  text-align: end;
-  font-size: 18px;
-  display: inline-block;
-  height: 30px;
   color: white;
+  font: inherit;
 }
 
 main .title incognito-checkbox {
   display: none;
-  margin-top: 10px;
 }
 
 main .title incognito-checkbox[mode="open"],
@@ -113,7 +115,6 @@ main .title h1 img {
   background-color: white;
   padding: 4px 16px;
 }
-
 
 /* key metrics */
 main .key-metrics ul {
@@ -299,16 +300,14 @@ figcaption > span {
 }
 
 .quick-filter input {
-  font-size: 20px;
   width: 100%;
   border: none;
+  border-bottom: 2px solid #ccc;
   border-radius: 0;
   padding: 12px;
   background-color: #eee;
-  border-bottom: 2px solid #ccc;
+  font: inherit;
 }
-
-
 
 fieldset {
   --background-color: var(--light-indigo);
@@ -791,26 +790,11 @@ a.drillup::after {
   main .title h1 {
     font-size: var(--type-heading-l-size);
   }
-
-  main .title select {
-    border-radius: 24px;
-    padding: 2px 8px;
-    font-size: 20px;
-    height: 32px;
-  }
-
 }
 
 @media (min-width: 900px) {
   main .title h1 {
     font-size: var(--type-heading-xl-size);
-  }
-
-  main .title select {
-    border-radius: 24px;
-    padding: 4px 16px;
-    font-size: 24px;
-    height: 40px;
   }
 
   main .title h1 img {

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -65,11 +65,11 @@ main li.score-poor, vitals-facet div[data-value^="poor"] label {
 /* heading */
 main .title div {
   display: flex;
-  align-items: center;
   gap: 1ch;
 }
 
 main .title select {
+  align-self: center;
   border: 2px solid var(--dark-blue);
   border-radius: 32px;
   padding: 2px 15px;
@@ -80,6 +80,7 @@ main .title select {
 
 main .title incognito-checkbox {
   display: none;
+  margin-bottom: 10px;
 }
 
 main .title incognito-checkbox[mode="open"],

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -275,7 +275,7 @@ const io = new IntersectionObserver((entries) => {
     elems.sidebar = sidebar;
 
     sidebar.addEventListener('facetchange', () => {
-      console.log('sidebar change');
+      // console.log('sidebar change');
       updateState();
       draw();
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

form elements (input, select) in rum explorer were using default browser font fallbacks. propose to inherit font styling for form elements.

See https://rum-fonts--helix-website--adobe.aem.page/tools/rum/explorer.html?domainkey=incognito.

## Screenshots (if appropriate):
Left: Previous.
Right: Suggested.
<img width="1170" alt="Screenshot 2024-06-06 at 12 08 47 PM" src="https://github.com/adobe/helix-website/assets/43383503/31240ec9-abf1-4a7d-9dd7-08ae756eec84">
<img width="1167" alt="Screenshot 2024-06-06 at 12 10 24 PM" src="https://github.com/adobe/helix-website/assets/43383503/76e6b02a-fce2-44c7-a518-874c84634ef6">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
