### PR TITLE
pagespeed link without using img tag

### DIFF
--- a/tools/rum/elements/link-facet.js
+++ b/tools/rum/elements/link-facet.js
@@ -16,12 +16,12 @@ export default class LinkFacet extends ListFacet {
       u.searchParams.set('proxyurl', labelText);
       return `
       <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="this.classList.add('broken')">
-      <a href="https://pagespeed.web.dev/analysis?url=${encodeURIComponent(labelText)}" target="_new"><img title="PageSpeed Insights" alt="PageSpeed Insights" class="pagespeed" src="/tools/rum/pagespeed_48.png"></a>
+      <a href="https://pagespeed.web.dev/analysis?url=${encodeURIComponent(labelText)}" target="_new"><div class="pagespeed"></div></a>
       <a href="${labelText}" target="_new">${labelText}</a>`;
     }
     if (labelText.startsWith('https://') || labelText.startsWith('http://')) {
       return `
-      <a href="https://pagespeed.web.dev/analysis?url=${encodeURIComponent(labelText)}" target="_new"><img title="PageSpeed Insights" alt="PageSpeed Insights" class="pagespeed" src="/tools/rum/pagespeed_48.png"></a>
+      <a href="https://pagespeed.web.dev/analysis?url=${encodeURIComponent(labelText)}" target="_new"><div class="pagespeed"></div></a>
       <a href="${labelText}" target="_new">${labelText}</a>`;
     }
     if (labelText.startsWith('referrer:')) {

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -655,8 +655,13 @@ vitals-facet fieldset label {
   opacity: 0;
 }
 
-#facets link-facet img.pagespeed {
+#facets link-facet div.pagespeed {
+  height: 40px;
   width: 40px;
+  background-image: url('/tools/rum/pagespeed_48.png');
+  background-size: contain;
+  display: inline;
+  cursor: pointer;
 }
 
 #facets fieldset div.load-more {


### PR DESCRIPTION
@trieloff requested css instead of img tag.  Not sure I did this right, hence different branch which we can easily abandon if not.

https://pagespeed-css--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=emigrationbrewing.com&view=month&domainkey=open