### PR TITLE
URL as custom element

### DIFF
--- a/tools/rum/elements/url-selector.js
+++ b/tools/rum/elements/url-selector.js
@@ -1,3 +1,7 @@
+function getPersistentToken() {
+  return localStorage.getItem('rum-bundler-token');
+}
+
 export default class URLSelector extends HTMLElement {
   constructor() {
     super();
@@ -17,6 +21,11 @@ export default class URLSelector extends HTMLElement {
           letter-spacing: -0.04em;
           border: 0;
         }
+
+        input:disabled {
+          background-color: none;
+          color: black;
+        }
       </style>
       <label for="url"><img src="https://www.aem.live/favicon.ico"></label>
       <input id="url" type="url">
@@ -29,6 +38,10 @@ export default class URLSelector extends HTMLElement {
     input.value = new URL(window.location.href).searchParams.get('domain');
     const img = this.querySelector('img');
     img.src = `https://www.google.com/s2/favicons?domain=${input.value}&sz=64`;
+
+    if (!getPersistentToken()) {
+      input.disabled = true;
+    }
 
     input.addEventListener('input', () => {
       this.dispatchEvent(new CustomEvent('change', { detail: input.value }));

--- a/tools/rum/elements/url-selector.js
+++ b/tools/rum/elements/url-selector.js
@@ -23,7 +23,7 @@ export default class URLSelector extends HTMLElement {
         }
 
         input:disabled {
-          background-color: none;
+          background-color: transparent;
           color: black;
         }
       </style>

--- a/tools/rum/elements/url-selector.js
+++ b/tools/rum/elements/url-selector.js
@@ -1,0 +1,34 @@
+export default class URLSelector extends HTMLHeadingElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          margin: 1em 0;
+        }
+        label {
+          display: block;
+          font-weight: bold;
+          margin-bottom: 0.5em;
+        }
+        input {
+          width: 100%;
+          padding: 0.5em;
+          font-size: 1em;
+        }
+      </style>
+      <label for="url">URL</label>
+      <input id="url" type="url" placeholder="https://example.com">
+    `;
+  }
+
+  get value() {
+    return this.shadowRoot.querySelector('input').value;
+  }
+
+  set value(value) {
+    this.shadowRoot.querySelector('input').value = value;
+  }
+}

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -43,7 +43,7 @@
         <div id="deepmain">
           <div class="output">
             <div class="title">
-              <h1><img src="https://www.aem.live/favicon.ico"> www.aem.live</h1>
+              <url-selector>www.aem.live</url-selector>
               <div>
                 <select id="view">
                   <option value="week">Week</option>

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -19,6 +19,7 @@
     import LinkFacet from './elements/link-facet.js';
     import LiteralFacet from './elements/literal-facet.js';
     import VitalsFacet from './elements/vitals-facet.js';
+    import URLSelector from './elements/url-selector.js';
     window.slicer = {
       Chart: SkylineChart,
     };
@@ -29,6 +30,7 @@
     customElements.define('link-facet', LinkFacet);
     customElements.define('literal-facet', LiteralFacet);
     customElements.define('vitals-facet', VitalsFacet);
+    customElements.define('url-selector', URLSelector);
   </script>
   <script src="./slicer.js" type="module"></script>
   <link rel="stylesheet" href="./rum-slicer.css">

--- a/tools/rum/flow.html
+++ b/tools/rum/flow.html
@@ -19,6 +19,7 @@
     import LinkFacet from './elements/link-facet.js';
     import LiteralFacet from './elements/literal-facet.js';
     import VitalsFacet from './elements/vitals-facet.js';
+    import URLSelector from './elements/url-selector.js';
     window.slicer = {
       Chart: SankeyChart,
     };
@@ -30,6 +31,7 @@
   customElements.define('link-facet', LinkFacet);
   customElements.define('literal-facet', LiteralFacet);
   customElements.define('vitals-facet', VitalsFacet);
+  customElements.define('url-selector', URLSelector);
   </script>
   <script src="./slicer.js" type="module"></script>
   <link rel="stylesheet" href="./rum-slicer.css">
@@ -42,7 +44,7 @@
       <div id="deepmain">
         <div class="output">
           <div class="title">
-            <h1><img src="https://www.aem.live/favicon.ico"> www.aem.live</h1>
+          <url-selector>www.aem.live</url-selector>
             <div>
               <select id="view">
                 <option value="week">Week</option>

--- a/tools/rum/list.html
+++ b/tools/rum/list.html
@@ -18,6 +18,7 @@
   import LinkFacet from './elements/link-facet.js';
   import LiteralFacet from './elements/literal-facet.js';
   import VitalsFacet from './elements/vitals-facet.js';
+  import URLSelector from './elements/url-selector.js';
   window.slicer = {
     Chart: BarChart,
   };
@@ -28,6 +29,7 @@
   customElements.define('link-facet', LinkFacet);
   customElements.define('literal-facet', LiteralFacet);
   customElements.define('vitals-facet', VitalsFacet);
+  customElements.define('url-selector', URLSelector);
   </script>
   <script src="./slicer.js" type="module"></script>
   <link rel="stylesheet" href="./rum-slicer.css">
@@ -40,7 +42,7 @@
       <div id="deepmain">
         <div class="output">
           <div class="title">
-            <h1><img src="https://www.aem.live/favicon.ico"> www.aem.live</h1>
+            <url-selector>www.aem.live</url-selector>
             <div>
               <select id="view">
                 <option value="week">Week</option>

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -95,7 +95,7 @@ main .title {
   align-items: center;
 }
 
-main .title h1 {
+main .title url-selector {
   margin-top: 8px;
   margin-bottom: 8px;
   font-size: var(--type-heading-m-size);
@@ -103,7 +103,7 @@ main .title h1 {
   align-items: center;
 }
 
-main .title h1 img {
+main .title url-selector img {
   height: 16px;
   margin-right: 8px;
 }
@@ -818,17 +818,17 @@ a.drillup::after {
 }
 
 @media (min-width: 600px) {
-  main .title h1 {
+  main .title url-selector input {
     font-size: var(--type-heading-l-size);
   }
 }
 
 @media (min-width: 900px) {
-  main .title h1 {
+  main .title url-selector input {
     font-size: var(--type-heading-xl-size);
   }
 
-  main .title h1 img {
+  main .title url-selector img {
     height: 32px;
   }
 

--- a/tools/rum/share.html
+++ b/tools/rum/share.html
@@ -18,6 +18,7 @@
   import LinkFacet from './elements/link-facet.js';
   import LiteralFacet from './elements/literal-facet.js';
   import VitalsFacet from './elements/vitals-facet.js';
+  import URLSelector from './elements/url-selector.js';
   window.slicer = {
     Chart: PieChart,
   };
@@ -28,6 +29,7 @@
   customElements.define('link-facet', LinkFacet);
   customElements.define('literal-facet', LiteralFacet);
   customElements.define('vitals-facet', VitalsFacet);
+  customElements.define('url-selector', URLSelector);
   </script>
   <script src="./slicer.js" type="module"></script>
   <link rel="stylesheet" href="./rum-slicer.css">
@@ -40,7 +42,7 @@
       <div id="deepmain">
         <div class="output">
           <div class="title">
-            <h1><img src="https://www.aem.live/favicon.ico"> www.aem.live</h1>
+            <url-selector>www.aem.live</url-selector>
             <div>
               <select id="view">
                 <option value="week">Week</option>

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -366,27 +366,6 @@ const io = new IntersectionObserver((entries) => {
     elems.viewSelect.value = view;
     setDomain(params.get('domain') || 'www.thinktanked.org', params.get('domainkey') || '');
     const focus = params.get('focus');
-    const h1 = document.querySelector('h1');
-    h1.textContent = ` ${DOMAIN}`;
-    const img = document.createElement('img');
-    img.src = `https://${DOMAIN}/favicon.ico`;
-    img.addEventListener('error', () => {
-      img.src = './website.svg';
-    });
-    h1.prepend(img);
-    h1.addEventListener('click', async () => {
-      // eslint-disable-next-line no-alert
-      let domain = window.prompt('enter domain or URL');
-      if (domain) {
-        try {
-          const url = new URL(domain);
-          domain = url.host;
-        } catch {
-          // nothing
-        }
-        window.location = `${window.location.pathname}?domain=${domain}&view=month`;
-      }
-    });
 
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     elems.timezoneElement.textContent = timezone;


### PR DESCRIPTION
This gets rid of the blocking `diaglog`

- **wip: new url selector custom element**
- **feat(rum-explorer): use input field in custom element instead of dialog for URL entry**
- **fix(rum-explorer): disable url entry if no key in local storage**
