### PR TITLE
feat(link-facet): add option to fall back to favicon, if no og:image can be found

### DIFF
--- a/tools/rum/elements/link-facet.js
+++ b/tools/rum/elements/link-facet.js
@@ -12,6 +12,7 @@ export default class LinkFacet extends ListFacet {
   createLabelHTML(labelText) {
     const thumbnailAtt = this.getAttribute('thumbnail');
     const pagespeedAtt = this.getAttribute('pagespeed');
+    const faviconAtt = this.getAttribute('favicon');
     if (pagespeedAtt && thumbnailAtt && labelText.startsWith('https://')) {
       const u = new URL('https://www.aem.live/tools/rum/_ogimage');
       u.searchParams.set('proxyurl', labelText);
@@ -24,7 +25,7 @@ export default class LinkFacet extends ListFacet {
       const u = new URL('https://www.aem.live/tools/rum/_ogimage');
       u.searchParams.set('proxyurl', labelText);
       return `
-      <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="this.classList.add('broken')">
+      <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="${faviconAtt ? `this.src='https://www.google.com/s2/favicons?domain=${labelText}&sz=256'` : 'this.classList.add(\'broken\');'}">
       <a href="${labelText}" target="_new">${labelText}</a>`;
     }
     if (labelText.startsWith('https://') || labelText.startsWith('http://')) {

--- a/tools/rum/elements/link-facet.js
+++ b/tools/rum/elements/link-facet.js
@@ -25,7 +25,7 @@ export default class LinkFacet extends ListFacet {
       const u = new URL('https://www.aem.live/tools/rum/_ogimage');
       u.searchParams.set('proxyurl', labelText);
       return `
-      <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="${faviconAtt ? `this.src='https://www.google.com/s2/favicons?domain=${labelText}&sz=256'` : 'this.classList.add(\'broken\');'}">
+      <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="${faviconAtt ? `this.src='https://www.google.com/s2/favicons?domain=${labelText}&sz=256';this.classList.add('favicon');` : 'this.classList.add(\'broken\');'}">
       <a href="${labelText}" target="_new">${labelText}</a>`;
     }
     if (labelText.startsWith('https://') || labelText.startsWith('http://')) {

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -180,7 +180,7 @@
             <literal-facet facet="viewblock.source" drilldown="list.html">
               <legend>Block (CSS Selector)</legend>
             </literal-facet>
-            <link-facet facet="enter.source" drilldown="list.html" thumbnail="false">
+            <link-facet facet="enter.source" drilldown="list.html" thumbnail="true" favicon="true">
               <legend>External Referrer</legend>
               <dl>
                 <dt>(direct)</dt>

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -655,6 +655,10 @@ vitals-facet fieldset label {
   opacity: 0;
 }
 
+#facets link-facet img.favicon {
+  object-fit: contain;
+}
+
 #facets fieldset div.load-more {
   grid-column: 2 / span 2;  
   display: block;


### PR DESCRIPTION
<img width="948" alt="Screenshot 2024-06-12 at 10 08 01" src="https://github.com/adobe/helix-website/assets/39613/feae35e7-4155-436f-9a08-160c201cdb51">
