### PR TITLE
feat(rum-explorer): hide protocol and hostname from link facet if there is not enough space

### DIFF
--- a/tools/rum/elements/link-facet.js
+++ b/tools/rum/elements/link-facet.js
@@ -1,6 +1,12 @@
 import { escapeHTML } from '../utils.js';
 import ListFacet from './list-facet.js';
 
+function labelURLParts(url) {
+  const u = new URL(url);
+  return ['protocol', 'hostname', 'port', 'pathname', 'search', 'hash']
+    .reduce((acc, part) => `${acc}<span class="${part}" title="${u.href}">${u[part]}</span>`, '');
+}
+
 /**
  * A custom HTML element to display a list of facets with links.
  * <link-facet facet="userAgent" drilldown="share.html" mode="all">
@@ -18,7 +24,7 @@ export default class LinkFacet extends ListFacet {
       u.searchParams.set('proxyurl', labelText);
       return `
       <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="this.classList.add('broken')">
-      <a href="${labelText}" target="_new">${labelText}</a>
+      <a href="${labelText}" target="_new">${labelURLParts(labelText)}</a>
       <a href="${pagespeedAtt}${encodeURIComponent(labelText)}" target="_new" class="icon pagespeed" title="Show pagespeed insights for ${labelText}">pagespeed</a>`;
     }
     if (thumbnailAtt && (labelText.startsWith('http://') || labelText.startsWith('https://') || labelText.startsWith('android-app://'))) {
@@ -26,7 +32,7 @@ export default class LinkFacet extends ListFacet {
       u.searchParams.set('proxyurl', labelText);
       return `
       <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="${faviconAtt ? `this.src='https://www.google.com/s2/favicons?domain=${labelText}&sz=256';this.classList.add('favicon');` : 'this.classList.add(\'broken\');'}">
-      <a href="${labelText}" target="_new">${labelText}</a>`;
+      <a href="${labelText}" target="_new">${labelURLParts(labelText)}</a>`;
     }
     if (labelText.startsWith('https://') || labelText.startsWith('http://')) {
       return `<a href="${labelText}" target="_new">${labelText}</a>`;

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -642,6 +642,33 @@ vitals-facet fieldset label {
   height: 60px;
 }
 
+#facets link-facet a .protocol::after {
+  content: '//';
+}
+
+/* don't worry, we'll show this when there is enough space */
+#facets link-facet  a .protocol {
+  display: none;
+}
+
+#facets link-facet  a .hostname {
+  display: none;
+}
+
+#facets facet-sidebar {
+  container-type: inline-size;
+  container-name: facets;
+}
+
+/* external referrer only care about the hostname anyway */
+#facets link-facet[facet="enter.source"] a .hostname {
+  display: inline;
+}
+
+#facets link-facet[facet="enter.source"] a .pathname {
+  display: none;
+}
+
 #facets link-facet img {
   height: 40px;
   width: 60px;
@@ -873,6 +900,14 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
   main .title url-selector input {
     font-size: var(--type-heading-l-size);
   }
+
+  #facets link-facet  a .protocol {
+    display: none;
+  }
+
+  #facets link-facet  a .hostname {
+    display: inline;
+  }
 }
 
 @media (min-width: 900px) {
@@ -925,7 +960,14 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
     padding: 4px 16px;
     font-size: 18px;
   }  
-  
+
+  #facets link-facet  a .protocol {
+    display: inline;
+  }
+
+  #facets link-facet  a .hostname {
+    display: inline;
+  }
 }
 
 
@@ -960,12 +1002,36 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
     display: block;
     padding-top: 0;
   }
+
+  #facets link-facet label {
+    /* don't let the line wrap */
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  #facets link-facet  a .protocol {
+    display: none;
+    opacity: 0.6;
+  }
+
+  #facets link-facet  a .hostname {
+    display: inline;
+  }
 }
 
 @media (min-width: 2000px) {
   main .key-metrics ul {
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   }  
+
+  #facets link-facet  a .protocol {
+    display: inline;
+  }
+
+  #facets link-facet  a .hostname {
+    display: inline;
+  }
 }
 
 footer.footer-wrapper.appear {


### PR DESCRIPTION
<img width="735" alt="Screenshot 2024-06-13 at 11 26 12" src="https://github.com/adobe/helix-website/assets/39613/7fa4819f-efd7-439b-bb8c-dfe1671fcaa1">
<img width="1100" alt="Screenshot 2024-06-13 at 11 26 04" src="https://github.com/adobe/helix-website/assets/39613/40dcbdbd-995d-4124-8057-bb95ffbc0b6c">
<img width="1779" alt="Screenshot 2024-06-13 at 11 25 34" src="https://github.com/adobe/helix-website/assets/39613/3cf899c2-a59f-4d3a-becd-ad44ded67b7d">
<img width="2223" alt="Screenshot 2024-06-13 at 11 25 17" src="https://github.com/adobe/helix-website/assets/39613/16c01f5e-d90b-417c-b289-af13e4af7d30">
<img width="2628" alt="Screenshot 2024-06-13 at 11 25 08" src="https://github.com/adobe/helix-website/assets/39613/de5c1af7-22df-4188-9c4a-f39f5b5fc7b3">
