### PR TITLE
Better visualization of paid and consent flows

### DIFF
--- a/tools/rum/charts/sankey.js
+++ b/tools/rum/charts/sankey.js
@@ -76,7 +76,7 @@ const stages = [
       detect: (bundle) => bundle.events
         .filter((e) => e.checkpoint === 'utm')
         .length === 0,
-      next: ['enter'],
+      next: ['enter', 'consent', 'noconsent'],
     },
     campaign: {
       label: 'Campaign',
@@ -84,7 +84,7 @@ const stages = [
       detect: (bundle) => bundle.events
         .filter((e) => e.checkpoint === 'utm' || e.checkpoint === 'paid')
         .length > 0,
-      next: ['enter'],
+      next: ['enter', 'consent', 'noconsent'],
     },
   },
   {
@@ -109,6 +109,24 @@ const stages = [
       label: 'Back/Forward',
       detect: (bundle) => bundle.events
         .filter((e) => e.checkpoint === 'back_forward')
+        .length > 0,
+      next: ['top', '404'],
+    },
+    consent: {
+      label: 'Consent Shown',
+      color: cssVariable('--spectrum-purple-500'),
+      detect: (bundle) => bundle.events
+        .filter((e) => e.checkpoint === 'consent')
+        .filter((e) => e.target === 'show')
+        .length > 0,
+      next: ['top', '404'],
+    },
+    noconsent: {
+      label: 'Consent Hidden',
+      color: cssVariable('--spectrum-seafoam-500'),
+      detect: (bundle) => bundle.events
+        .filter((e) => e.checkpoint === 'consent')
+        .filter((e) => e.target === 'hidden')
         .length > 0,
       next: ['top', '404'],
     },
@@ -202,7 +220,7 @@ const stages = [
       */
     nocontent: {
       label: 'No Content',
-      color: cssVariable('--spectrum-gray-800'),
+      color: cssVariable('--spectrum-gray-200'),
       next: ['click', 'formsubmit', 'nointeraction'],
       detect: (bundle) => bundle.events
         .filter((e) => e.checkpoint === 'viewmedia' || e.checkpoint === 'viewblock')

--- a/tools/rum/charts/sankey.js
+++ b/tools/rum/charts/sankey.js
@@ -22,7 +22,7 @@ Chart.register(SankeyController, Flow, ...registerables);
 // 'pagesviewed',
 'error',
 'navigate',
-'utm',
+'utm', // replace with 'paid'
 'reload',
 'back_forward',
 'lcp',
@@ -82,7 +82,7 @@ const stages = [
       label: 'Campaign',
       color: cssVariable('--spectrum-red-400'),
       detect: (bundle) => bundle.events
-        .filter((e) => e.checkpoint === 'utm')
+        .filter((e) => e.checkpoint === 'utm' || e.checkpoint === 'paid')
         .length > 0,
       next: ['enter'],
     },

--- a/tools/rum/charts/sankey.js
+++ b/tools/rum/charts/sankey.js
@@ -258,7 +258,7 @@ const stages = [
     },
     nointeraction: {
       label: 'No Interaction',
-      color: cssVariable('--spectrum-gray-900'),
+      color: cssVariable('--spectrum-gray-100'),
       detect: (bundle) => bundle.events
         .filter((e) => e.checkpoint === 'click'
           || e.checkpoint === 'formsubmit')

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -157,7 +157,7 @@
                 <dd>Clicked</dd>
                 <dt>error</dt>
                 <dd>JavaScript Error</dd>
-                <dt>utm</dt>
+                <dt>paid</dt>
                 <dd>Marketing Campaigns</dd>
                 <dt>consent</dt>
                 <dd>Consent</dd>
@@ -207,6 +207,31 @@
                 <dd>Dialog Hidden</dd>
               </dl>
             </list-facet>
+
+            <list-facet facet="paid.source">
+              <legend>Ad Network</legend>
+              <dl>
+                <dt>google</dt>
+                <dd>Google Ads</dd>
+                <dt>doubleclick</dt>
+                <dd>DoubleClick</dd>
+                <dt>microsoft</dt>
+                <dd>Microsoft Ads</dd>
+                <dt>facebook</dt>
+                <dd>Facebook Ads</dd>
+                <dt>twitter</dt>
+                <dd>Twitter Ads</dd>
+                <dt>linkedin</dt>
+                <dd>LinkedIn Ads</dd>
+                <dt>Pinterest</dt>
+                <dd>Pinterest Ads</dd>
+                <dt>tiktok</dt>
+                <dd>TikTok Ads</dd>
+              </dl>
+            </list-facet>
+            <literal-facet facet="paid.target">
+              <legend>Click Tracking Parameter</legend>
+            </literal-facet>
 
             <link-facet facet="error.source">
               <legend>Error Source</legend>

--- a/tools/rum/flow.html
+++ b/tools/rum/flow.html
@@ -157,7 +157,7 @@
               <dd>Clicked</dd>
               <dt>error</dt>
               <dd>JavaScript Error</dd>
-              <dt>utm</dt>
+              <dt>paid</dt>
               <dd>Marketing Campaigns</dd>
               <dt>consent</dt>
               <dd>Consent</dd>


### PR DESCRIPTION
In explorer, we'll use the `paid` checkpoint instead of UTM to detect bought traffic. (see https://adobe.enterprise.slack.com/files/W5BPKRLUA/F077XV2J4JE/screenshot_2024-06-13_at_11.39.02.png)
In the sankey diagram, we use lighter colors for the no content and no interaction nodes, making them visually lighter
Sankey also shows now three ways of entering (consent shown, consent hidden, normal enter). (see https://adobe.enterprise.slack.com/files/W5BPKRLUA/F077S4128QN/screenshot_2024-06-13_at_14.20.41.png)


- **feat(rum-explorer): add `paid` facet instead of `utm` facet**
- **feat(rum-explorer): use `paid` checkpoint in addition to `utm` checkpoint for sankey**
- **fix(sankey): no interaction is white, leading to less washed-out gradients**
- **feat(sankey): show consent/noconsent upon enter**
