### PR TITLE
chore: add styling to thumbnail facet

### DIFF
--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -507,7 +507,7 @@ thumbnail-facet label {
   gap: 1em;
 }
 
-thumbnail-facet fieldset div {
+thumbnail-facet fieldset div:not(.more-container) {
   border-bottom: 1px solid currentcolor;
   padding-top: 4px;
   padding-bottom: 4px;

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -501,45 +501,18 @@ vitals-facet label::before {
   padding: 2px 4px;
 }
 
-thumbnail-facet input[type=checkbox] {
-  opacity: 0.1;
-  z-index: -1;
+thumbnail-facet label {
+  display: flex;
+  align-items: center;
+  gap: 1em;
 }
 
-thumbnail-facet input[type=checkbox] + label {
-  margin-left: -30px;
-  z-index: 1;
-  display: grid;
-  place-items: center;
-  place-content: start;
+thumbnail-facet fieldset div {
+  border-bottom: 1px solid currentcolor;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
-thumbnail-facet label > * {
-  grid-row-start: 1;
-  grid-column-start: 1;
-}
-
-thumbnail-facet input[type=checkbox]:checked + label img {
-  /* add a blue glow */
-  box-shadow: 0 0 2px 2px var(--dark-blue);
-  margin: 2px;
-}
-
-thumbnail-facet label span.count::after, thumbnail-facet label span.count::before {
-  display: none;
-}
-
-thumbnail-facet label span.count {
-  z-index: 2;
-  background-color: white;
-  padding: 0 15px;
-  border-radius: 20px;
-  display: block;
-}
-
-thumbnail-facet fieldset div:hover label span.count {
-  opacity: 0.1;
-}
 
 vitals-facet fieldset {
   display: grid;


### PR DESCRIPTION
https://rum-thumbnail-facet--helix-website--adobe.aem.page/tools/rum/explorer.html?domain=emigrationbrewing.com&filter=&view=month&checkpoint=viewmedia&domainkey=open&conversion.checkpoint=click

<img width="1152" alt="image" src="https://github.com/adobe/helix-website/assets/5289336/a0d6bf09-aa19-412c-bd94-9439989a8c17">


vs. 

https://main--helix-website--adobe.aem.page/tools/rum/explorer.html?domain=emigrationbrewing.com&filter=&view=month&checkpoint=viewmedia&domainkey=open&conversion.checkpoint=click

<img width="1151" alt="image" src="https://github.com/adobe/helix-website/assets/5289336/87db572a-da22-4105-87fd-70749e0ccb9a">

