### PR TITLE
fix: center arrow

### DIFF
--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -787,7 +787,7 @@ a.drilldown::before {
   border: 2px solid;
   border-width: 0 2px 0 0;
   top: 1px;
-  left: 6px;
+  left: 7px;
 }
 
 /* and the downward facing triangle */


### PR DESCRIPTION
## Description

The drilldown/up arrows are not properly centered.  There may be another preferred fix solution in CSS.

Before:
<img width="27" alt="Screenshot 2024-06-18 at 5 00 38 PM" src="https://github.com/adobe/helix-website/assets/33439846/f2564967-a063-4904-b26b-b534151c88e5">

After:
<img width="27" alt="Screenshot 2024-06-18 at 5 02 47 PM" src="https://github.com/adobe/helix-website/assets/33439846/c92fc9ce-6d04-48e0-981c-00068aed709f">
https://arrow--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=emigrationbrewing.com&view=month&domainkey=open

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
