### PR TITLE
fix(rum-enhancer) computing conversions can be filtered further on the visitors subset

### DIFF
--- a/tools/rum/cruncher.js
+++ b/tools/rum/cruncher.js
@@ -557,9 +557,23 @@ export class DataChunks {
    * checkpoint attribute set to 'click' must exist.
    * @param {string} combiner used to determine if all or some filters must match.
    * By default, 'every' is used.
+   * @param {boolean} isVisiting calculate the conversion of the visiting
+   * set instead of the entire dataset. Useful when calculating the conversion
+   * rate in relation to visits
    * @returns {boolean} the result of the check.
    */
-  hasConversion(aBundle, filterSpec, combiner) {
+  hasConversion(aBundle, filterSpec, combiner, isVisiting = true) {
+    if (isVisiting) {
+      // the visiting filter is just about `enter` checkpoints
+      // see addCalculatedProps function
+      const checkpoints = filterSpec.checkpoint;
+      if (checkpoints) {
+        checkpoints.push('enter');
+      } else {
+        filterSpec.checkpoint = ['enter'];
+      }
+    }
+
     const existenceFilterFn = ([facetName]) => this.facetFns[facetName];
     const skipFilterFn = () => true;
     const valuesExtractorFn = (attributeName, bundle, parent) => {


### PR DESCRIPTION
Proposal for computing conversions out of the visitor subset instead of the entire dataset. 

Before this 

Notice that before the conversion numbers were higher because they were related to the entire data set, with this fix, it only looks into the visitors - this has also the consequence that conversion rates will never exeed 100% since conversion rates are computed against visitors.