### PR TITLE
Hide Non-Significant Conversion Rate

### DIFF
--- a/tools/rum/elements/list-facet.js
+++ b/tools/rum/elements/list-facet.js
@@ -237,7 +237,7 @@ export default class ListFacet extends HTMLElement {
             total: entry.metrics.visits.sum / avgWeight,
             conversions: entry.metrics.conversions.sum / avgWeight,
           }, {
-            total: this.dataChunks.totals.pageViews.sum / avgWeight,
+            total: this.dataChunks.totals.visits.sum / avgWeight,
             conversions: this.dataChunks.totals.conversions.sum / avgWeight,
           });
 

--- a/tools/rum/elements/list-facet.js
+++ b/tools/rum/elements/list-facet.js
@@ -234,7 +234,7 @@ export default class ListFacet extends HTMLElement {
             / this.dataChunks.totals.pageViews.count;
 
           addSignificanceFlag(conversionspan, {
-            total: entry.metrics.pageViews.sum / avgWeight,
+            total: entry.metrics.visits.sum / avgWeight,
             conversions: entry.metrics.conversions.sum / avgWeight,
           }, {
             total: this.dataChunks.totals.pageViews.sum / avgWeight,

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -576,9 +576,22 @@ vitals-facet label::before {
   opacity: 1;
 }
 
+#facets fieldset label span.extra {
+  display: none;
+}
+
+#facets fieldset label span.extra.interesting {
+  display: inline;
+  opacity: 0.8;
+}
+
+#facets fieldset label span.extra.significant {
+  display: inline;
+  opacity: 0.9;
+}
+
 #facets fieldset label span.count::before,
-#facets fieldset label span.value::before,
-#facets fieldset label span.extra::before {
+#facets fieldset label span.value::before {
   content: ' (';
 }
 
@@ -587,11 +600,11 @@ vitals-facet label::before {
 }
 
 #facets fieldset label span.count::after, #facets fieldset label span.value::after {
-  content: ')';
+  content: ') ';
 }
 
 #facets fieldset label span.extra::after {
-  content: '%)';
+  content: '% conversion rate';
 }
 
 #facets literal-facet label span.value::after {

--- a/tools/rum/test/cruncher.test.js
+++ b/tools/rum/test/cruncher.test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { readFileSync } from 'node:fs';
-import { DataChunks, addCalculatedProps } from '../cruncher.js';
+import { DataChunks, addCalculatedProps, zTestTwoProportions } from '../cruncher.js';
 
 describe('cruncher.js helper functions', () => {
   it('addCalculatedProps()', () => {
@@ -151,6 +151,11 @@ describe('cruncher.js helper functions', () => {
     assert.equal(after.visit, undefined);
     assert.equal(after.conversion, undefined);
     assert.equal(after.cwvINP, 24);
+  });
+
+  it('zTestTwoProportions()', () => {
+    const p = zTestTwoProportions(100, 1000, 100, 1000);
+    assert.equal(p, 1);
   });
 });
 


### PR DESCRIPTION
The current conversion rate display is a bit noisy. With this change,
no conversion rate will be shown for most facets. If the facet has
a significantly different conversion rate from the baseline, then it
will be shown. The greater the significance, the greater the opacity of
the label. This allows you to quickly spot facets (or segments) that
are worthy of attention.

- **feat(rum-explorer): add significance flag to conversion rates display**
- **fix(rum-explorer): better styling for interesting and significant conversion rate differences**
