### PR TITLE
fix(rum-explorer) use a cached value of the conversion spec

### DIFF
--- a/tools/rum/utils.js
+++ b/tools/rum/utils.js
@@ -195,11 +195,14 @@ export function parseSearchParams(params, filterFn, transformFn) {
       return acc;
     }, {});
 }
+const cached = {};
 export function parseConversionSpec() {
+  if (cached.conversionSpec) return cached.conversionSpec;
   const params = new URL(window.location).searchParams;
   const transform = ([key, value]) => [key.replace('conversion.', ''), value];
   const filter = ([key]) => (key.startsWith('conversion.'));
-  return parseSearchParams(params, filter, transform);
+  cached.conversionSpec = parseSearchParams(params, filter, transform);
+  return cached.conversionSpec;
 }
 
 /**


### PR DESCRIPTION
Use a cached value for the conversion spec that is computed when the page is loaded.