### PR TITLE
feat(oversight): add trend indicators when looking at date-range chart

### DIFF
--- a/tools/oversight/charts/skyline.js
+++ b/tools/oversight/charts/skyline.js
@@ -16,6 +16,7 @@ import {
   getGradient,
 } from '../utils.js';
 import AbstractChart from './chart.js';
+import { linearRegression } from '../cruncher.js';
 
 Chart.register(TimeScale, LinearScale, ...registerables);
 
@@ -582,5 +583,15 @@ export default class SkylineChart extends AbstractChart {
     this.clsAlreadyLabeled = false;
     this.lcpAlreadyLabeled = false;
     this.chart.update();
+
+    // add trend indicators
+    const trafficTrend = linearRegression(allTraffic);
+    const iGoodLCPTrend = linearRegression(iGoodLCPs);
+    const iGoodCLSTrend = linearRegression(iGoodCLSs);
+    const iGoodINPTrend = linearRegression(iGoodINPs);
+    document.querySelector('.key-metrics #pageviews number-format').setAttribute('trend', trafficTrend.slope > 0 ? 'rising' : 'falling');
+    document.querySelector('.key-metrics #lcp number-format').setAttribute('trend', iGoodLCPTrend.slope > 0 ? 'rising' : 'falling');
+    document.querySelector('.key-metrics #cls number-format').setAttribute('trend', iGoodCLSTrend.slope > 0 ? 'rising' : 'falling');
+    document.querySelector('.key-metrics #inp number-format').setAttribute('trend', iGoodINPTrend.slope > 0 ? 'rising' : 'falling');
   }
 }

--- a/tools/oversight/cruncher.js
+++ b/tools/oversight/cruncher.js
@@ -255,6 +255,45 @@ export function tTest(left, right) {
   return p;
 }
 
+/**
+ * @typedef Line
+ * @type {Object}
+ * @property {number} slope the slope of the linear function,
+ * i.e. increase of y for every increase of x
+ * @property {number} intercept the intercept of the linear function,
+ * i.e. the value of y for x equals zero
+ */
+/**
+ * Peform a linear ordinary squares regression against an array.
+ * This regression takes the array index as the independent variable
+ * and the data in the array as the dependent variable.
+ * @param {number[]} data an array of input data
+ * @returns {Line} the slope and intercept of the regression function
+ */
+export function linearRegression(data) {
+  const { length: n } = data;
+
+  if (n === 0) {
+    throw new Error('Array must contain at least one element.');
+  }
+
+  // Calculate sumX and sumX2 using Gauss's formulas
+  const sumX = ((n - 1) * n) / 2;
+  const sumX2 = ((n - 1) * n * (2 * n - 1)) / 6;
+
+  // Calculate sumY and sumXY using reduce with destructuring
+  const { sumY, sumXY } = data.reduce((acc, y, x) => {
+    acc.sumY += y;
+    acc.sumXY += x * y;
+    return acc;
+  }, { sumY: 0, sumXY: 0 });
+
+  const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+
+  return { slope, intercept };
+}
+
 class Facet {
   constructor(parent, value, name) {
     this.parent = parent;

--- a/tools/oversight/elements/number-format.js
+++ b/tools/oversight/elements/number-format.js
@@ -48,6 +48,9 @@ export default class NumberFormat extends HTMLElement {
         this.classList.add(`${findNearestVulgarFraction(fraction)}-of-total`);
       }
     }
+    if (this.getAttribute('trend')) {
+      this.title += ` and ${this.getAttribute('trend')}`;
+    }
     // resume observing
     this.mutationObserver.observe(this, { childList: true });
   }

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -195,6 +195,23 @@ main facet-sidebar ul.cwv > li number-format[title="no data available"]::after {
   content: '';
 }
 
+main .key-metrics number-format[trend="falling"],
+main .key-metrics #lcp number-format[trend="rising"],
+main .key-metrics #cls number-format[trend="rising"],
+main .key-metrics #inp number-format[trend="rising"] {
+  border-bottom: 1px solid;
+  border-color: var(--spectrum-red-600);
+}
+
+main .key-metrics number-format[trend="rising"],
+/* more isn't always better */
+main .key-metrics #lcp number-format[trend="falling"],
+main .key-metrics #cls number-format[trend="falling"],
+main .key-metrics #inp number-format[trend="falling"] {
+  border-bottom: 1px solid;
+  border-color: var(--spectrum-green-600);
+}
+
 .key-metrics > ul > * {
   border: 1px solid currentcolor;
   border-radius: 8px;


### PR DESCRIPTION
See https://oversight-trends--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=www.aem.live&filter=&view=month&checkpoint=cwv-lcp&conversion.checkpoint=click

<img width="2650" alt="Screenshot 2024-07-03 at 12 50 23" src="https://github.com/adobe/helix-website/assets/39613/78716cc5-23b1-4400-be5a-e3b017dc5cc5">

Note the little line below some of the key metrics, indicating if the trend shows an improvement over time