### PR TITLE
Oversight: don't inflate conversion rates

### DIFF
--- a/tools/oversight/consent.js
+++ b/tools/oversight/consent.js
@@ -1,0 +1,37 @@
+const vendors = {
+  onetrust: {
+    match: /#(onetrust|ot)-/,
+    accept: /accept/,
+    reject: /reject/,
+    dismiss: /close-pc-btn-handler/,
+  },
+  usercentrics: {
+    match: /#usercentrics-root/,
+    // we don't have nicely id'd buttons here
+  },
+  truste: {
+    match: /#truste/,
+    accept: /consent-button/,
+    dismiss: /close/,
+  },
+  cybot: {
+    match: /#CybotCookiebot/,
+    accept: /AllowAll/,
+    reject: /Decline/,
+  },
+};
+
+export default function classifyConsent(cssSelector) {
+  return cssSelector
+    && (Object.entries(vendors)
+      .filter(([, { match }]) => match.test(cssSelector))
+      .map(([vendor, spec]) => ({
+        checkpoint: 'consent',
+        source: vendor,
+        target: Object.entries(spec)
+          .filter(([key]) => key !== 'match')
+          .filter(([, pattern]) => pattern.test(cssSelector))
+          .map(([key]) => key)
+          .pop(),
+      }))).pop();
+}

--- a/tools/oversight/elements/conversion-tracker.js
+++ b/tools/oversight/elements/conversion-tracker.js
@@ -21,7 +21,7 @@ export default class ConversionTracker extends HTMLElement {
     if (this.getAttribute('mode') === 'pending') {
       this.button.textContent = 'confirm';
       this.button.disabled = false;
-    } else if (conversionDef.length === 1 && conversionDef[0][0] === 'checkpoint' && conversionDef[0][1] === 'click' && filterDef.length === 0) {
+    } else if (conversionDef.length === 0 || (conversionDef.length === 1 && conversionDef[0][0] === 'checkpoint' && conversionDef[0][1] === 'click' && filterDef.length === 0)) {
       this.button.textContent = 'default';
       this.button.disabled = true;
       this.setAttribute('mode', 'default');
@@ -31,6 +31,8 @@ export default class ConversionTracker extends HTMLElement {
     } else {
       this.button.textContent = 'reset';
       this.button.disabled = false;
+      this.querySelector('h2').textContent = 'Conversions';
+      this.title = 'Custom conversion definition';
       this.setAttribute('mode', 'custom');
     }
   }

--- a/tools/oversight/elements/number-format.js
+++ b/tools/oversight/elements/number-format.js
@@ -7,7 +7,9 @@ export default class NumberFormat extends HTMLElement {
   }
 
   connectedCallback() {
-    this.mutationObserver = new MutationObserver(() => this.updateState());
+    this.mutationObserver = new MutationObserver(() => {
+      this.updateState();
+    });
     this.updateState();
     this.mutationObserver.observe(this, { childList: true });
   }
@@ -15,7 +17,7 @@ export default class NumberFormat extends HTMLElement {
   updateState() {
     // stop observing while updating
     this.mutationObserver.disconnect();
-    const number = parseFloat(this.getAttribute('title')) || parseFloat(this.textContent, 10);
+    const number = parseFloat(this.textContent, 10);
     const sampleSize = parseInt(this.getAttribute('sample-size'), 10);
     const total = parseInt(this.getAttribute('total'), 10);
     const precision = parseInt(this.getAttribute('precision'), 10);

--- a/tools/oversight/elements/url-selector.js
+++ b/tools/oversight/elements/url-selector.js
@@ -69,6 +69,7 @@ export default class URLSelector extends HTMLElement {
         goto.searchParams.set('view', 'month');
         window.location.href = goto.href;
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.error('Invalid URL', e, event.detail);
       }
     });

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -67,8 +67,8 @@
                   <h2>Visits</h2>
                   <p><number-format>0</number-format></p>
                 </li>
-                <conversion-tracker id="conversions" title="Page views with a user click">
-                  <h2>Conversions</h2>
+                <conversion-tracker id="conversions" title="Page views with a user click outside a consent dialog">
+                  <h2>Engagement</h2>
                   <p><number-format>0</number-format></p>
                 </conversion-tracker>
                 <li id="lcp" title="Largest Contentful Paint">

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -202,6 +202,12 @@
               <dl>
                 <dt>onetrust</dt>
                 <dd>OneTrust</dd>
+                <dt>truste</dt>
+                <dd>TrustArc</dd>
+                <dt>usercentrics</dt>
+                <dd>Usercentrics</dd>
+                <dt>cybot</dt>
+                <dd>Cybot</dd>
               </dl>
             </list-facet>
             <list-facet facet="consent.target">
@@ -211,6 +217,10 @@
                 <dd>Dialog Shown</dd>
                 <dt>hidden</dt>
                 <dd>Dialog Hidden</dd>
+                <dt>accept</dt>
+                <dd>Consent provided</dd>
+                <dt>reject</dt>
+                <dd>Consent withheld</dd>
               </dl>
             </list-facet>
 

--- a/tools/oversight/flow.html
+++ b/tools/oversight/flow.html
@@ -68,8 +68,8 @@
                 <h2>Visits</h2>
                 <p><number-format>0</number-format></p>
               </li>
-              <conversion-tracker id="conversions" title="Page views with a user click">
-                <h2>Conversions</h2>
+              <conversion-tracker id="conversions" title="Page views with a user click outside a consent dialog">
+                <h2>Engagement</h2>
                 <p><number-format>0</number-format></p>
               </conversion-tracker>
               <li id="lcp" title="Largest Contentful Paint">

--- a/tools/oversight/list.html
+++ b/tools/oversight/list.html
@@ -64,10 +64,10 @@
                 <h2>Visits</h2>
                 <p><number-format>0</number-format></p>
               </li>
-              <conversion-tracker id="conversions" title="Page views with a user click">
-                <h2>Conversions</h2>
+              <conversion-tracker id="conversions" title="Page views with a user click outside a consent dialog">
+                <h2>Engagement</h2>
                 <p><number-format>0</number-format></p>
-                </conversion-tracker>
+              </conversion-tracker>
               <li id="lcp" title="Largest Contentful Paint">
                 <h2>LCP</h2>
                 <p><number-format precision="2" fuzzy="false">0</number-format></p>

--- a/tools/oversight/list.html
+++ b/tools/oversight/list.html
@@ -195,6 +195,12 @@
               <dl>
                 <dt>onetrust</dt>
                 <dd>OneTrust</dd>
+                <dt>truste</dt>
+                <dd>TrustArc</dd>
+                <dt>usercentrics</dt>
+                <dd>Usercentrics</dd>
+                <dt>cybot</dt>
+                <dd>Cybot</dd>
               </dl>
             </list-facet>
             <list-facet facet="consent.target">
@@ -204,6 +210,10 @@
                 <dd>Dialog Shown</dd>
                 <dt>hidden</dt>
                 <dd>Dialog Hidden</dd>
+                <dt>accept</dt>
+                <dd>Consent provided</dd>
+                <dt>reject</dt>
+                <dd>Consent withheld</dd>
               </dl>
             </list-facet>
             <link-facet facet="error.source">

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -636,7 +636,7 @@ vitals-facet label::before {
 }
 
 #facets fieldset label .extra::after {
-  content: '% conversion rate';
+  content: '% rate';
 }
 
 #facets fieldset label number-format[title="0"].extra::after {

--- a/tools/oversight/share.html
+++ b/tools/oversight/share.html
@@ -198,6 +198,12 @@
               <dl>
                 <dt>onetrust</dt>
                 <dd>OneTrust</dd>
+                <dt>truste</dt>
+                <dd>TrustArc</dd>
+                <dt>usercentrics</dt>
+                <dd>Usercentrics</dd>
+                <dt>cybot</dt>
+                <dd>Cybot</dd>
               </dl>
             </list-facet>
             <list-facet facet="consent.target">
@@ -207,6 +213,10 @@
                 <dd>Dialog Shown</dd>
                 <dt>hidden</dt>
                 <dd>Dialog Hidden</dd>
+                <dt>accept</dt>
+                <dd>Consent provided</dd>
+                <dt>reject</dt>
+                <dd>Consent withheld</dd>
               </dl>
             </list-facet>
             <link-facet facet="error.source">

--- a/tools/oversight/share.html
+++ b/tools/oversight/share.html
@@ -66,10 +66,10 @@
                 <h2>Visits</h2>
                 <p><number-format>0</number-format></p>
               </li>
-              <conversion-tracker id="conversions" title="Page views with a user click">
-                <h2>Conversions</h2>
+              <conversion-tracker id="conversions" title="Page views with a user click outside a consent dialog">
+                <h2>Engagement</h2>
                 <p><number-format>0</number-format></p>
-                </conversion-tracker>
+              </conversion-tracker>
               <li id="lcp" title="Largest Contentful Paint">
                 <h2>LCP</h2>
                 <p><number-format precision="2" fuzzy="false">0</number-format></p>

--- a/tools/oversight/single.html
+++ b/tools/oversight/single.html
@@ -81,10 +81,10 @@
                 <h2>Visits</h2>
                 <p><number-format>0</number-format></p>
               </li>
-              <conversion-tracker id="conversions" title="Page views with a user click">
-                <h2>Conversions</h2>
+              <conversion-tracker id="conversions" title="Page views with a user click outside a consent dialog">
+                <h2>Engagement</h2>
                 <p><number-format>0</number-format></p>
-                </conversion-tracker>
+              </conversion-tracker>
               <li id="lcp" title="Largest Contentful Paint">
                 <h2>LCP</h2>
                 <p><number-format precision="2" fuzzy="false">0</number-format></p>

--- a/tools/oversight/utils.js
+++ b/tools/oversight/utils.js
@@ -1,3 +1,5 @@
+import classifyConsent from './consent.js';
+
 /* helpers */
 export function scoreValue(value, ni, poor) {
   if (value >= poor) return 'poor';
@@ -283,4 +285,12 @@ export function roundToConfidenceInterval(
 
   const rounded = toHumanReadable(total, precision);
   return rounded;
+}
+
+export function reclassifyConsent({ source, target, checkpoint }) {
+  if (checkpoint === 'click' && source) {
+    const consent = classifyConsent(source);
+    if (consent) return consent;
+  }
+  return { source, target, checkpoint };
 }


### PR DESCRIPTION
Following main changes:
- if no conversion target has been defined, we report "Engagement" instead
- "Engaged" are page views that have a click outside a consent dialog
- Conversions are calculated against visits, engagement against page views
- We detect clicks to common consent vendors and break them out under the `consent` checkpoint

See https://cq-dev.slack.com/archives/C07198KKQ07/p1720645069632019
