### PR TITLE
feat(RUM Explorer): performance - only render the necessary DOM elements

### DIFF
--- a/tools/rum/elements/list-facet.js
+++ b/tools/rum/elements/list-facet.js
@@ -196,9 +196,11 @@ export default class ListFacet extends HTMLElement {
       const filteredKeys = filterKeys && this.placeholders
         ? optionKeys.filter((a) => !!(this.placeholders[a]))
         : optionKeys;
-      facetEntries
-        .filter((entry) => !filterKeys || filteredKeys.includes(entry.value))
-        .forEach((entry) => {
+
+      const paint = (start = 0, end = numOptions) => {
+        const entries = facetEntries
+          .filter((entry) => !filterKeys || filteredKeys.includes(entry.value));
+        entries.slice(start, end).forEach((entry) => {
           const div = document.createElement('div');
           const input = document.createElement('input');
           input.type = 'checkbox';
@@ -266,10 +268,22 @@ export default class ListFacet extends HTMLElement {
           ul.append(inpLI);
 
           div.append(input, label, ul);
-          fieldSet.append(div);
-        });
 
-      if (filteredKeys.length > 10) {
+          const more = fieldSet.querySelector('.more-container');
+          if (more) {
+            more.before(div);
+          } else {
+            fieldSet.append(div);
+          }
+        });
+      };
+
+      paint();
+
+      if (filteredKeys.length > numOptions) {
+        const container = document.createElement('div');
+        container.classList.add('more-container');
+
         // add "more" link
         const div = document.createElement('div');
         div.className = 'load-more';
@@ -277,15 +291,13 @@ export default class ListFacet extends HTMLElement {
         more.textContent = 'more...';
         more.addEventListener('click', (evt) => {
           evt.preventDefault();
-          if (this.classList.contains('more')) {
-            const mores = Array.from(this.classList)
-              .filter((c) => c.startsWith('more'));
-            // add a more-more-more with the length of
-            // the existing mores + 1
-            const moreClass = Array.from({ length: mores.length + 1 }, () => 'more').join('-');
-            this.classList.add(moreClass);
+          const start = fieldSet.children.length - 2; // minus the "legend" and "more" container
+          const end = start + numOptions;
+          paint(start, end);
+
+          if (end >= filteredKeys.length) {
+            container.remove();
           }
-          this.classList.add('more');
         });
 
         div.append(more);
@@ -294,11 +306,14 @@ export default class ListFacet extends HTMLElement {
         all.textContent = `all (${filteredKeys.length})`;
         all.addEventListener('click', (evt) => {
           evt.preventDefault();
-          this.classList.add('more-all');
+
+          const start = fieldSet.children.length - 2; // minus the "legend" and "more" container
+          paint(start, filteredKeys.length);
+
+          container.remove();
         });
         div.append(all);
-        const container = document.createElement('div');
-        container.classList.add('more-container');
+
         container.append(div);
         fieldSet.append(container);
       }

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -514,49 +514,6 @@ vitals-facet label::before {
   display: grid;
 }
 
-#facets .more-all fieldset div.more-container div.load-more label {
-  display: none;
-}
-
-#facets .more-more-more fieldset div.more-container div.load-more label:first-of-type {
-  /* that's enough */
-  display: none;
-}
-
-#facets fieldset div:nth-child(11) ~ div {
-  display: none;
-}
-
-#facets .more-all fieldset div:nth-child(11) ~ div,
-#facets .more.more-all fieldset div:nth-child(11) ~ div{
-  display: grid;
-}
-
-#facets .more fieldset div:nth-child(11) ~ div {
-  display: grid;
-}
-
-#facets .more fieldset div:nth-child(21) ~ div {
-  display: none;
-}
-
-#facets .more-more fieldset div:nth-child(21) ~ div {
-  display: grid;
-}
-
-#facets .more-more fieldset div:nth-child(31) ~ div {
-  display: none;
-}
-
-#facets .more-more-more fieldset div:nth-child(31) ~ div {
-  display: grid;
-}
-
-#facets .more-more-more fieldset div:nth-child(41) ~ div {
-  display: none;
-}
-
-
 #facets fieldset input[type=checkbox] {
   grid-area: check;
   height: 20px;


### PR DESCRIPTION
One of the reason why the rendering is so slow is because we added all entries to a facet but only show 10 and manage the "add more" by css (sic!).
When there are 20 entries, that's ok but when there are 4k, the DOM is huge and computing + appending becomes expensive.