### PR TITLE
feat(rum-explorer): metrics on demand and defer conversions

### DIFF
--- a/tools/rum/cruncher.js
+++ b/tools/rum/cruncher.js
@@ -280,19 +280,34 @@ class Facet {
    * @returns {Aggregate} metrics
    */
   get metrics() {
-    if (this.metricsIn) return this.metricsIn;
-    if (this.entries.length === 0) {
+    return this.getMetrics(Object.keys(this.parent.series));
+  }
+
+  getMetrics(series) {
+    if (!series || series.length === 0) return {};
+    const res = {};
+    const needed = [];
+    if (this.metricsIn) {
+      series.forEach((s) => {
+        if (this.metricsIn[s]) {
+          res[s] = this.metricsIn[s];
+        } else {
+          needed.push(s);
+        }
+      });
+    } else {
       this.metricsIn = {};
-      return this.metricsIn;
+      needed.push(...series);
     }
 
-    this.metricsIn = Object.entries(this.parent.series)
-      .reduce((acc, [seriesName, valueFn]) => {
-        acc[seriesName] = this.entries.reduce(aggregateFn(valueFn), new Aggregate());
-        return acc;
-      }, {});
-
-    return this.metricsIn;
+    if (needed.length) {
+      needed.forEach((s) => {
+        const valueFn = this.parent.series[s];
+        this.metricsIn[s] = this.entries.reduce(aggregateFn(valueFn), new Aggregate());
+        res[s] = this.metricsIn[s];
+      });
+    }
+    return res;
   }
 }
 

--- a/tools/rum/elements/list-facet.js
+++ b/tools/rum/elements/list-facet.js
@@ -220,7 +220,7 @@ export default class ListFacet extends HTMLElement {
             });
           }
 
-          const metrics = entry.getMetrics(['pageViews', 'visits', 'conversions']);
+          const metrics = entry.getMetrics(['pageViews', 'visits']);
 
           const label = document.createElement('label');
           label.setAttribute('for', `${facetName}-${entry.value}`);
@@ -233,24 +233,30 @@ export default class ListFacet extends HTMLElement {
           const conversionspan = document.createElement('span');
           conversionspan.className = 'extra';
 
-          // we need to divide the totals by average weight
-          // so that we don't overestimate the significance
-          const avgWeight = this.dataChunks.totals.pageViews.weight
-            / this.dataChunks.totals.pageViews.count;
+          const $this = this;
+          const drawConversion = () => {
+            // we need to divide the totals by average weight
+            // so that we don't overestimate the significance
+            const m = entry.getMetrics(['conversions']);
+            const avgWeight = $this.dataChunks.totals.pageViews.weight
+              / $this.dataChunks.totals.pageViews.count;
 
-          addSignificanceFlag(conversionspan, {
-            total: metrics.visits.sum / avgWeight,
-            conversions: metrics.conversions.sum / avgWeight,
-          }, {
-            total: this.dataChunks.totals.visits.sum / avgWeight,
-            conversions: this.dataChunks.totals.conversions.sum / avgWeight,
-          });
+            addSignificanceFlag(conversionspan, {
+              total: metrics.visits.sum / avgWeight,
+              conversions: m.conversions.sum / avgWeight,
+            }, {
+              total: $this.dataChunks.totals.visits.sum / avgWeight,
+              conversions: $this.dataChunks.totals.conversions.sum / avgWeight,
+            });
 
-          const conversions = metrics.conversions.sum;
-          const visits = metrics.visits.sum;
-          const conversionRate = computeConversionRate(conversions, visits);
-          conversionspan.textContent = toHumanReadable(conversionRate);
-          conversionspan.title = metrics.conversions.sum;
+            const conversions = m.conversions.sum;
+            const visits = metrics.visits.sum;
+            const conversionRate = computeConversionRate(conversions, visits);
+            conversionspan.textContent = toHumanReadable(conversionRate);
+            conversionspan.title = m.conversions.sum;
+          };
+
+          window.setTimeout(drawConversion, 0);
 
           label.append(valuespan, countspan, conversionspan);
 

--- a/tools/rum/elements/list-facet.js
+++ b/tools/rum/elements/list-facet.js
@@ -390,7 +390,7 @@ export default class ListFacet extends HTMLElement {
       li.textContent = cwv;
     };
     // fill the element, but don't wait for it
-    fillEl();
+    window.setTimeout(fillEl, 0);
     return li;
   }
 }

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -473,10 +473,12 @@ fieldset li[class$="-"] {
 
 fieldset li.interesting {
   border-width: 2px;
+  padding: 2px 5px;
 }
 
 fieldset li.significant {
   border-width: 3px;
+  padding: 2px 4px;
 }
 
 fieldset li::after,


### PR DESCRIPTION
Compute only necessary metrics.
Conversions computation is really expensive (x20 the others). Moving to a `setTimeout` boost the user experience.
Also optimized the CWV rendering with a `setTimeout` (the promise approach does not work) - required minor CSS adjustment to avoid CLS.

This makes the total metrics computation during rendering around 13% faster.

Test page: https://less-metrics--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=www.bulk.com&filter=&view=week&domainkey=