### PR TITLE
Oversight/Sankey: Classify Acquisition Sources

### DIFF
--- a/tools/oversight/acquisition.js
+++ b/tools/oversight/acquisition.js
@@ -36,6 +36,7 @@ const vendorClassifications = [
   { regex: /yandex/i, result: 'yandex' },
   { regex: /baidu/i, result: 'baidu' },
   { regex: /amazon|ctv/i, result: 'amazon' },
+  { regex: /direct/i, result: 'direct' },
 ];
 
 /* is the vendor paid or owned */
@@ -44,6 +45,7 @@ const vendorTypeLookup = {
   reddit: 'paid',
   tiktok: 'paid',
   amazon: 'paid',
+  direct: 'earned',
 };
 
 const categoryClassifications = [
@@ -97,6 +99,7 @@ const vendorCategoryLookup = {
   amazon: 'display',
   yandex: 'search',
   baidu: 'search',
+  direct: 'direct',
 };
 
 const categoryTypeLookup = {

--- a/tools/oversight/acquisition.js
+++ b/tools/oversight/acquisition.js
@@ -110,7 +110,7 @@ const categoryTypeLookup = {
   print: 'owned',
 };
 
-function vendor(origin) {
+export function vendor(origin) {
   return vendorClassifications
     .reduce((result, classification) => (
       !result && classification.regex.test(origin)
@@ -140,11 +140,11 @@ function paidowned(origin, vendorResult, categoryResult) {
   return vendorTypeLookup[vendorResult] || categoryTypeLookup[categoryResult] || '';
 }
 
-export default function classifyAcquisition(origin, isPaid = false) {
+export function classifyAcquisition(origin, isPaid = false) {
   const vendorResult = vendor(origin);
   const categoryResult = category(origin, vendorResult);
   const paidOwnedResult = isPaid
-    ? 'paid'
+    ? (typeof isPaid === 'string' && isPaid) || 'paid'
     : paidowned(origin, vendorResult, categoryResult);
 
   let result = paidOwnedResult;

--- a/tools/oversight/acquisition.js
+++ b/tools/oversight/acquisition.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+const vendorClassifications = [
+  { regex: /google|googleads|google-ads|google_search|google_deman|adwords|dv360|gdn|doubleclick|dbm|gmb/i, result: 'google' },
+  { regex: /instagram|ig/i, result: 'instagram' },
+  { regex: /facebook|fb|meta/i, result: 'facebook' },
+  { regex: /bing/i, result: 'bing' },
+  { regex: /tiktok/i, result: 'tiktok' },
+  { regex: /youtube|yt/i, result: 'youtube' },
+  { regex: /linkedin/i, result: 'linkedin' },
+  { regex: /twitter/i, result: 'x' },
+  { regex: /snapchat/i, result: 'snapchat' },
+  { regex: /microsoft/i, result: 'microsoft' },
+  { regex: /pinterest/i, result: 'pinterest' },
+  { regex: /reddit/i, result: 'reddit' },
+  { regex: /spotify/i, result: 'spotify' },
+  { regex: /criteo/i, result: 'criteo' },
+  { regex: /taboola/i, result: 'taboola' },
+  { regex: /outbrain/i, result: 'outbrain' },
+  { regex: /yahoo/i, result: 'yahoo' },
+  { regex: /marketo/i, result: 'marketo' },
+  { regex: /eloqua/i, result: 'eloqua' },
+  { regex: /substack/i, result: 'substack' },
+  { regex: /line/i, result: 'line' },
+  { regex: /yext/i, result: 'yext' },
+  { regex: /teads/i, result: 'teads' },
+  { regex: /yandex/i, result: 'yandex' },
+  { regex: /baidu/i, result: 'baidu' },
+  { regex: /amazon|ctv/i, result: 'amazon' },
+];
+
+/* is the vendor paid or owned */
+const vendorTypeLookup = {
+  yext: 'paid',
+  reddit: 'paid',
+  tiktok: 'paid',
+  amazon: 'paid',
+};
+
+const categoryClassifications = [
+  { regex: /search|sem|sea$/i, result: 'search' },
+  { regex: /display|programmatic|banner|gdn|dbm/i, result: 'display' },
+  { regex: /video|dv360|tv/i, result: 'video' },
+  { regex: /email|newsletter/i, result: 'email' },
+  { regex: /social|bio/i, result: 'social' },
+  { regex: /affiliate/i, result: 'affiliate' },
+  { regex: /local|gmb/i, result: 'local' },
+  { regex: /sms/i, result: 'sms' },
+  { regex: /qr/i, result: 'qr' },
+  { regex: /push/i, result: 'push' },
+  { regex: /print/i, result: 'print' },
+  { regex: /web/i, result: 'web' },
+];
+
+const paidOwnedClassifications = [
+  { regex: /cpc|ppc|paid|cpm|cpv|banner|display|programmatic|affiliate|^sea$|ads|dv360/i, result: 'paid' },
+  // "organic" is treated as "owned" as it is not paid and not earned
+  // (noone puts UTM tags on real organic traffic)
+  { regex: /email|newsletter|hs_email|organic|sms|qr|qrcode|print|website|web|linkin.bio/i, result: 'owned' },
+  { regex: /push/i, result: 'owned' },
+  { regex: /gmb/i, result: '' },
+  // { regex: /social/i, result: 'earned' },
+];
+
+const vendorCategoryLookup = {
+  google: 'search',
+  bing: 'search',
+  yahoo: 'search',
+  facebook: 'social',
+  instagram: 'social',
+  linkedin: 'social',
+  x: 'social',
+  snapchat: 'social',
+  pinterest: 'social',
+  reddit: 'social',
+  youtube: 'video',
+  spotify: 'display',
+  yext: 'local',
+  line: 'social',
+  substack: 'email',
+  outbrain: 'display',
+  taboola: 'display',
+  criteo: 'display',
+  eloqua: 'email',
+  microsoft: 'display',
+  marketo: 'email',
+  tiktok: 'video',
+  amazon: 'display',
+  yandex: 'search',
+  baidu: 'search',
+};
+
+const categoryTypeLookup = {
+  search: 'paid',
+  display: 'paid',
+  affiliate: 'paid',
+  email: 'owned',
+  web: 'owned',
+  sms: 'owned',
+  qr: 'owned',
+  print: 'owned',
+};
+
+function vendor(origin) {
+  return vendorClassifications
+    .reduce((result, classification) => (
+      !result && classification.regex.test(origin)
+        ? classification.result
+        : result), '');
+}
+
+function category(origin, vendorResult) {
+  const categoryResult = categoryClassifications
+    .reduce((result, classification) => (
+      !result && classification.regex.test(origin)
+        ? classification.result
+        : result), '');
+
+  if (categoryResult) return categoryResult;
+  return vendorCategoryLookup[vendorResult] || '';
+}
+
+function paidowned(origin, vendorResult, categoryResult) {
+  const paidOwnedResult = paidOwnedClassifications
+    .reduce((result, classification) => (
+      !result && classification.regex.test(origin)
+        ? classification.result
+        : result), '');
+
+  if (paidOwnedResult) return paidOwnedResult;
+  return vendorTypeLookup[vendorResult] || categoryTypeLookup[categoryResult] || '';
+}
+
+export default function classifyAcquisition(origin, isPaid = false) {
+  const vendorResult = vendor(origin);
+  const categoryResult = category(origin, vendorResult);
+  const paidOwnedResult = isPaid
+    ? 'paid'
+    : paidowned(origin, vendorResult, categoryResult);
+
+  let result = paidOwnedResult;
+  if (categoryResult || vendorResult) {
+    result += `:${categoryResult}`;
+  }
+  if (vendorResult) {
+    result += `:${vendorResult}`;
+  }
+  return result;
+}

--- a/tools/oversight/charts/sankey.js
+++ b/tools/oversight/charts/sankey.js
@@ -119,7 +119,12 @@ const stages = [
       detect: (bundle) => bundle.events
         .filter((e) => e.checkpoint === 'enter')
         .filter((e) => !e.source.startsWith('http'))
-        .length > 0,
+        .length > 0
+        || bundle.events
+          .filter((e) => e.checkpoint === 'acquisition')
+          .filter((e) => e.source)
+          .filter(({ source }) => source.match(/direct/))
+          .length > 0,
       next: ['earned', 'owned', 'paid'],
       color: cssVariable('--spectrum-green-300'),
     },
@@ -137,8 +142,8 @@ const stages = [
       detect: (bundle) => bundle.events
         .filter((e) => e.checkpoint === 'utm'
           || e.checkpoint === 'paid'
-          || e.checkpoint === 'email'
-          || e.checkpoint === 'acquisition')
+          || (e.checkpoint === 'acquisition' && e.source && !e.source.startsWith('earned'))
+          || e.checkpoint === 'email')
         .length === 0,
       next: ['enter', 'consent', 'noconsent'],
     },

--- a/tools/oversight/elements/number-format.js
+++ b/tools/oversight/elements/number-format.js
@@ -17,9 +17,12 @@ export default class NumberFormat extends HTMLElement {
   updateState() {
     // stop observing while updating
     this.mutationObserver.disconnect();
+    const isPureNumber = !!this.textContent.trim().match(/^\d+(\.\d+)?$/);
     const titleValue = parseFloat((this.getAttribute('title') || '').replace(/ .*/g, ''), 10);
     const contentValue = parseFloat(this.textContent, 10);
-    const number = titleValue > contentValue ? titleValue : contentValue;
+    const number = isPureNumber
+      ? contentValue
+      : titleValue || contentValue;
 
     const sampleSize = parseInt(this.getAttribute('sample-size'), 10);
     const total = parseInt(this.getAttribute('total'), 10);

--- a/tools/oversight/elements/number-format.js
+++ b/tools/oversight/elements/number-format.js
@@ -17,7 +17,10 @@ export default class NumberFormat extends HTMLElement {
   updateState() {
     // stop observing while updating
     this.mutationObserver.disconnect();
-    const number = parseFloat(this.textContent, 10);
+    const titleValue = parseFloat((this.getAttribute('title') || '').replace(/ .*/g, ''), 10);
+    const contentValue = parseFloat(this.textContent, 10);
+    const number = titleValue > contentValue ? titleValue : contentValue;
+
     const sampleSize = parseInt(this.getAttribute('sample-size'), 10);
     const total = parseInt(this.getAttribute('total'), 10);
     const precision = parseInt(this.getAttribute('precision'), 10);

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -161,8 +161,8 @@
                 <dd>Clicked</dd>
                 <dt>error</dt>
                 <dd>JavaScript Error</dd>
-                <dt>paid</dt>
-                <dd>Marketing Campaigns</dd>
+                <dt>acquisition</dt>
+                <dd>Traffic Acquisition</dd>
                 <dt>consent</dt>
                 <dd>Consent</dd>
                 <dt>navigate</dt>

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -224,7 +224,7 @@
               </dl>
             </list-facet>
 
-            <list-facet facet="acquisition.source" drilldown="share.html">
+            <list-facet facet="acquisition.source">
               <legend>Inorganic Traffic Source</legend>
               <dl>
                 <dt>paid</dt>

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -224,30 +224,69 @@
               </dl>
             </list-facet>
 
-            <list-facet facet="paid.source">
-              <legend>Ad Network</legend>
+            <list-facet facet="acquisition.source" drilldown="share.html">
+              <legend>Inorganic Traffic Source</legend>
               <dl>
-                <dt>google</dt>
+                <dt>paid</dt>
+                <dd>All paid traffic</dd>
+                <dt>owned</dt>
+                <dd>All owned traffic</dd>
+                <dt>earned</dt>
+                <dd>All earned traffic</dd><!-- this is not being classified yet -->
+                <dt>paid:search</dt>
+                <dd>Paid Search</dd>
+                <dt>paid:search:google</dt>
                 <dd>Google Ads</dd>
-                <dt>doubleclick</dt>
-                <dd>DoubleClick</dd>
-                <dt>microsoft</dt>
-                <dd>Microsoft Ads</dd>
-                <dt>facebook</dt>
+                <dt>paid:search:bing</dt>
+                <dd>Bing Ads</dd>
+                <dt>paid:search:yahoo</dt>
+                <dd>Yahoo Ads</dd>
+                
+                <dt>paid:social</dt>
+                <dd>Paid Social Media</dd>
+                <dt>paid:social:facebook</dt>
                 <dd>Facebook Ads</dd>
-                <dt>twitter</dt>
-                <dd>Twitter Ads</dd>
-                <dt>linkedin</dt>
+                <dt>paid:social:twitter</dt>
+                <dd>X Ads</dd>
+                <dt>paid:social:linkedin</dt>
                 <dd>LinkedIn Ads</dd>
-                <dt>Pinterest</dt>
+                <dt>paid:social:instagram</dt>
+                <dd>Instagram Ads</dd>
+                <dt>paid:social:pinterest</dt>
                 <dd>Pinterest Ads</dd>
-                <dt>tiktok</dt>
+                <dt>paid:display</dt>
+                <dd>Paid Display</dd>
+                <dt>paid:display:google</dt>
+                <dd>Google Display Ads</dd>
+                <dt>paid:display:microsoft</dt>
+                <dd>Microsoft Display Ads</dd>
+                
+                <dt>paid:video</dt>
+                <dd>Paid Video</dd>
+                <dt>paid:video:youtube</dt>
+                <dd>YouTube Ads</dd>
+                <dt>paid:video:tiktok</dt>
                 <dd>TikTok Ads</dd>
+                <dt>:social</dt>
+                <dd>Paid or owned Social Media</dd>
+                <dt>:social:facebook</dt>
+                <dd>Facebook</dd>
+                <dt>:social:twitter</dt>
+                <dd>X</dd>
+                <dt>:social:linkedin</dt>
+                <dd>LinkedIn</dd>
+                <dt>:social:instagram</dt>
+                <dd>Instagram</dd>
+                <dt>:social:pinterest</dt>
+                <dd>Pinterest</dd>
+                
+                <dt>owned:email</dt>
+                <dd>Email</dd>
+                <dt>owned:email:organic</dt>
+                <dd>Marketo Email</dd>
+
               </dl>
             </list-facet>
-            <literal-facet facet="paid.target">
-              <legend>Click Tracking Parameter</legend>
-            </literal-facet>
 
             <link-facet facet="error.source">
               <legend>Error Source</legend>

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -219,40 +219,28 @@ function updateDataFacets(filterText, params, checkpoint) {
           .filter(({ source }) => source) // filter out empty sources
           .reduce((acc, { source }) => { acc.add(source); return acc; }, new Set()),
       ));
-      if (cp !== 'utm') { // utm.target is different from the other checkpoints
-        dataChunks.addFacet(`${cp}.target`, (bundle) => Array.from(
-          bundle.events
-            .map(reclassifyConsent)
-            .map(reclassifyAcquisition)
-            .filter((evt) => evt.checkpoint === cp)
-            .filter(({ target }) => target) // filter out empty targets
-            .reduce((acc, { target }) => { acc.add(target); return acc; }, new Set()),
-        ));
+      dataChunks.addFacet(`${cp}.target`, (bundle) => Array.from(
+        bundle.events
+          .map(reclassifyConsent)
+          .map(reclassifyAcquisition)
+          .filter((evt) => evt.checkpoint === cp)
+          .filter(({ target }) => target) // filter out empty targets
+          .reduce((acc, { target }) => { acc.add(target); return acc; }, new Set()),
+      ));
 
-        if (cp === 'loadresource') {
-          // loadresource.target are not discrete values, but the number
-          // of milliseconds it took to load the resource, so the best way
-          // to present this is to create a histogram
-          // we already have the `loadresource.target` facet, so we can
-          // extract the values from there and create a histogram
-          dataChunks.addHistogramFacet(
-            'loadresource.histogram',
-            'loadresource.target',
-            {
-              count: 10, min: 0, max: 10000, steps: 'quantiles',
-            },
-          );
-        }
-      } else if (params.has('utm.source')) {
-        params.getAll('utm.source').forEach((utmsource) => {
-          dataChunks.addFacet(`utm.${utmsource}.target`, (bundle) => Array.from(
-            bundle.events
-              .filter((evt) => evt.checkpoint === 'utm')
-              .filter((evt) => evt.source === utmsource)
-              .filter((evt) => evt.target)
-              .reduce((acc, { target }) => { acc.add(target); return acc; }, new Set()),
-          ));
-        });
+      if (cp === 'loadresource') {
+        // loadresource.target are not discrete values, but the number
+        // of milliseconds it took to load the resource, so the best way
+        // to present this is to create a histogram
+        // we already have the `loadresource.target` facet, so we can
+        // extract the values from there and create a histogram
+        dataChunks.addHistogramFacet(
+          'loadresource.histogram',
+          'loadresource.target',
+          {
+            count: 10, min: 0, max: 10000, steps: 'quantiles',
+          },
+        );
       }
     });
 

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -249,13 +249,6 @@ function updateDataFacets(filterText, params, checkpoint) {
             .filter((evt) => evt.checkpoint === cp)
             .filter(({ source }) => source) // filter out empty sources
             .map(({ source }) => source.split(':'))
-            /*
-            const parts = bundle.userAgent.split(':');
-            return parts.reduce((acc, _, i) => {
-              acc.push(parts.slice(0, i + 1).join(':'));
-              return acc;
-            }, []);
-            */
             .map((source) => source
               .reduce((acc, _, i) => {
                 acc.push(source.slice(0, i + 1).join(':'));

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -255,7 +255,7 @@ function updateDataFacets(filterText, params, checkpoint) {
                 return acc;
               }, [])
               .filter((s) => s))
-            .pop(),
+            .pop() || [],
         ));
       }
     });

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -8,6 +8,7 @@ import {
   scoreCWV,
   computeConversionRate,
   reclassifyConsent,
+  reclassifyAcquisition,
 } from './utils.js';
 
 /* globals */
@@ -165,6 +166,7 @@ function updateDataFacets(filterText, params, checkpoint) {
 
   dataChunks.addFacet('checkpoint', (bundle) => Array.from(bundle.events
     .map(reclassifyConsent)
+    .map(reclassifyAcquisition)
     .reduce((acc, evt) => {
       acc.add(evt.checkpoint);
       return acc;
@@ -212,6 +214,7 @@ function updateDataFacets(filterText, params, checkpoint) {
       dataChunks.addFacet(`${cp}.source`, (bundle) => Array.from(
         bundle.events
           .map(reclassifyConsent)
+          .map(reclassifyAcquisition)
           .filter((evt) => evt.checkpoint === cp)
           .filter(({ source }) => source) // filter out empty sources
           .reduce((acc, { source }) => { acc.add(source); return acc; }, new Set()),
@@ -220,6 +223,7 @@ function updateDataFacets(filterText, params, checkpoint) {
         dataChunks.addFacet(`${cp}.target`, (bundle) => Array.from(
           bundle.events
             .map(reclassifyConsent)
+            .map(reclassifyAcquisition)
             .filter((evt) => evt.checkpoint === cp)
             .filter(({ target }) => target) // filter out empty targets
             .reduce((acc, { target }) => { acc.add(target); return acc; }, new Set()),

--- a/tools/oversight/utils.js
+++ b/tools/oversight/utils.js
@@ -1,5 +1,5 @@
 import classifyConsent from './consent.js';
-import { classifyAcquisition, vendor } from './acquisition.js';
+import { classifyAcquisition } from './acquisition.js';
 
 /* helpers */
 export function scoreValue(value, ni, poor) {
@@ -327,16 +327,17 @@ export function reclassifyEnter(acc, event) {
   if (event.checkpoint === 'acquisition') acc.acquisition = event.source;
   if (acc.referrer && acc.acquisition && (event.checkpoint === 'enter' || event.checkpoint === 'acquisition')) {
     const [aGroup, aCategory, aVendor] = (acc.acquisition || '').split(':');
-    const [rGroup, rCategory, rVendor] = (classifyAcquisition(acc.referrer) || '').split(':');
-    const group = aGroup || 'earned';
+    const [, rCategory, rVendor] = (classifyAcquisition(acc.referrer) || '').split(':');
+    const group = aGroup || 'owned';
     const category = rCategory || aCategory;
     const vndr = rVendor || aVendor;
     const newsrc = `${group}:${category}:${vndr}`.replace(/:undefined/g, '');
     acc.push({ checkpoint: 'acquisition', source: newsrc });
     if (acc.acquisition !== newsrc) {
-      console.log('reclassified', acc.acquisition, 'with', acc.referrer, 'to', newsrc);
+      // console.log('reclassified', acc.acquisition, 'with', acc.referrer, 'to', newsrc);
     }
-  } else {
+  }
+  if (event.checkpoint !== 'acquisition') {
     acc.push(event);
   }
   return acc;

--- a/tools/oversight/utils.js
+++ b/tools/oversight/utils.js
@@ -1,4 +1,5 @@
 import classifyConsent from './consent.js';
+import classifyAcquisition from './acquisition.js';
 
 /* helpers */
 export function scoreValue(value, ni, poor) {
@@ -294,6 +295,20 @@ export function reclassifyConsent({ source, target, checkpoint }) {
   if (checkpoint === 'click' && source) {
     const consent = classifyConsent(source);
     if (consent) return consent;
+  }
+  return { source, target, checkpoint };
+}
+
+export function reclassifyAcquisition({ source, target, checkpoint }) {
+  if (checkpoint === 'utm' && (source === 'utm_source' || source === 'utm_medium')) {
+    const acquisition = classifyAcquisition(target);
+    if (acquisition) return { checkpoint: 'acquisition', source: acquisition };
+  } else if (checkpoint === 'paid') {
+    const acquisition = classifyAcquisition(source, true);
+    if (acquisition) return { checkpoint: 'acquisition', source: acquisition };
+  } else if (checkpoint === 'email') {
+    const acquisition = classifyAcquisition(source, false);
+    if (acquisition) return { checkpoint: 'acquisition', source: acquisition };
   }
   return { source, target, checkpoint };
 }

--- a/tools/patches.sh
+++ b/tools/patches.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+## do the following to set up the list of patch files
+
+# OLDBRANCH=$1
+# NEWBRANCH=$2
+
+# git checkout $OLDBRANCH
+# git format-patch main
+# git checkout main
+# git checkout -b $NEWBRANCH
+# git checkout $NEWBRANCH
+
+## you will now have a directory of files called 0001-your-commit-message.patch
+## that you could, under normal circumstances just apply using `git am`. But
+## we need to change the patch path from tools/rum to tools/oversight so we do
+## that with `sed`
+
+for patch in 0*-*.patch; do
+  cat $patch | sed -e "s|tools/rum/|tools/oversight/|g" | git am --3way && rm $patch
+done
+
+## If any of these patches fails, the script will abort and leave your working copy
+## in a slightly dirty stage. The right way to get out of this is to:
+## fix the merge conflict in your favorite editor
+# git add tools/oversight/conflicted.js    # tell git that the conflict has been resolved
+# git am --continue                        # reuse the original commit message, author, etc
+# rm 0003-the-patch-that-failed.patch      # remove the patch file, so that we don't try this again next
+# sh patches.sh                            # apply remaining patches, hope for fewer conflicts
+
+## The wrong way to get out of this, but that will still leave you with a clean working copy is
+# rm 0*-*.patch                            # remove all patch files
+# git am --abort                           # forget about this whole `git am` thing


### PR DESCRIPTION
This creates a sparser (and hopefully more readable) Sankey diagram.

The first column groups acquisition sources into:
- Search
- Social
- Email
- Local
- Display
- (plus internal navigation, reload, etc)

The second column groups the type of traffic acquisition:
- Paid
- Owned
- Earned

The rest stays almost as is, except that nodes for explicit link clicks have been removed

Preview: https://cq-dev.slack.com/archives/C07198KKQ07/p1721072766659269

- **feat(oversight): classify traffic acquisition**
- **fix(oversight): remove special handling of utm parameter**
- **feat(oversight): display traffic sources**
- **fix(oversight): remove drilldown for traffic source**
- **fix(oversight): more number format tweaks**
- **fix(oversight): guard against empty iterator**
- **refactor(sankey): use new traffic source classification**
