### PR TITLE
feat(rum-oversight): cleanup backport

### DIFF
--- a/tools/oversight/elements/link-facet.js
+++ b/tools/oversight/elements/link-facet.js
@@ -17,15 +17,13 @@ export default class LinkFacet extends ListFacet {
   // eslint-disable-next-line class-methods-use-this
   createLabelHTML(labelText) {
     const thumbnailAtt = this.getAttribute('thumbnail');
-    const pagespeedAtt = this.getAttribute('pagespeed');
     const faviconAtt = this.getAttribute('favicon');
-    if (pagespeedAtt && thumbnailAtt && labelText.startsWith('https://')) {
+    if (thumbnailAtt && labelText.startsWith('https://')) {
       const u = new URL('https://www.aem.live/tools/rum/_ogimage');
       u.searchParams.set('proxyurl', labelText);
       return `
       <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="this.classList.add('broken')">
-      <a href="${labelText}" target="_new">${labelURLParts(labelText)}</a>
-      <a href="${pagespeedAtt}${encodeURIComponent(labelText)}" target="_new" class="icon pagespeed" title="Show pagespeed insights for ${labelText}">pagespeed</a>`;
+      <a href="${labelText}" target="_new">${labelURLParts(labelText)}</a>`;
     }
     if (thumbnailAtt && (labelText.startsWith('http://') || labelText.startsWith('https://') || labelText.startsWith('android-app://'))) {
       const u = new URL('https://www.aem.live/tools/rum/_ogimage');

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -140,8 +140,7 @@
                 <dd>Social Media Bot</dd>
               </dl>
             </list-facet>
-            <link-facet facet="url" drilldown="list.html" thumbnail="true" highlight="filter"
-              pagespeed="https://pagespeed.web.dev/analysis?url=">
+            <link-facet facet="url" drilldown="list.html" thumbnail="true" highlight="filter">
               <legend>URL</legend>
             </link-facet>
             <list-facet facet="checkpoint" drilldown="flow.html" highlight="filter">

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -972,14 +972,6 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
   main .title url-selector input {
     font-size: var(--type-heading-l-size);
   }
-
-  #facets link-facet  a .protocol {
-    display: none;
-  }
-
-  #facets link-facet  a .hostname {
-    display: inline;
-  }
 }
 
 @media (min-width: 900px) {
@@ -1032,14 +1024,6 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
     padding: 4px 16px;
     font-size: 18px;
   }
-
-  #facets link-facet  a .protocol {
-    display: inline;
-  }
-
-  #facets link-facet  a .hostname {
-    display: inline;
-  }
 }
 
 
@@ -1081,28 +1065,11 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
     white-space: nowrap;
     overflow: hidden;
   }
-
-  #facets link-facet  a .protocol {
-    display: none;
-    opacity: 0.6;
-  }
-
-  #facets link-facet  a .hostname {
-    display: inline;
-  }
 }
 
 @media (min-width: 2000px) {
   main .key-metrics ul {
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  }
-
-  #facets link-facet  a .protocol {
-    display: inline;
-  }
-
-  #facets link-facet  a .hostname {
-    display: inline;
   }
 }
 

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -825,34 +825,6 @@ vitals-facet fieldset label {
   left: 2px;
 }
 
-.pagespeed {
-  display: inline-block;
-  margin-left: 0;
-  vertical-align: text-bottom;
-}
-
-.pagespeed::before {
-  border: 3px solid;
-  border-left: 0;
-  border-bottom: 0;
-  border-top-right-radius: 12px;
-  top: 2px;
-  left: 2px;
-  height: 10px;
-  width: 10px;
-  transform: rotate(-45deg);
-}
-
-.pagespeed::after {
-  height: 2px;
-  border-bottom: 1px solid;
-  background: currentcolor;
-  bottom: 6px;
-  left: 3px;
-  width: 10px;
-  transform: rotate(-70deg);
-}
-
 .clipboard-paste::before {
   border: 2px solid;
   border-bottom-left-radius: 3px;


### PR DESCRIPTION
Some requested backports:

- remove pagespeed icon
- never show protocol and hostname in URLs