### PR TITLE
fix: un-matched filter

### DIFF
--- a/tools/oversight/cruncher.js
+++ b/tools/oversight/cruncher.js
@@ -553,7 +553,7 @@ export class DataChunks {
 
   resetData() {
     // data that has been filtered
-    this.filteredIn = [];
+    this.filteredIn = null;
     // filtered data that has been grouped
     this.groupedIn = {};
     // grouped data that has been aggregated
@@ -738,7 +738,7 @@ export class DataChunks {
   }
 
   get filtered() {
-    if (this.filteredIn.length) return this.filteredIn;
+    if (this.filteredIn) return this.filteredIn;
     if (Object.keys(this.filters).length === 0) return this.bundles; // no filter, return all
     if (Object.keys(this.facetFns).length === 0) return this.bundles; // no facets, return all
     this.filteredIn = this.filterBundles(this.bundles, this.filters);

--- a/tools/oversight/elements/list-facet.js
+++ b/tools/oversight/elements/list-facet.js
@@ -337,6 +337,9 @@ export default class ListFacet extends HTMLElement {
         setTimeout(() => { toast.ariaHidden = true; }, 3000);
       });
       this.append(fieldSet);
+    } else {
+      const fieldSet = this.querySelector('fieldset');
+      if (fieldSet) fieldSet.remove();
     }
   }
 

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -189,7 +189,7 @@ function updateDataFacets(filterText, params, checkpoint) {
   dataChunks.addFacet('filter', (bundle) => {
     // this function is also a bit weird, because it takes
     // the filtertext into consideration
-    const fullText = bundle.url + bundle.events.map((e) => e.checkpoint).join(' ');
+    const fullText = `${bundle.url} ${bundle.events.map((e) => e.checkpoint).join(' ')}`;
     const keywords = filterText
       .split(' ')
       .filter((word) => word.length > 2);

--- a/tools/rum/cruncher.js
+++ b/tools/rum/cruncher.js
@@ -514,7 +514,7 @@ export class DataChunks {
 
   resetData() {
     // data that has been filtered
-    this.filteredIn = [];
+    this.filteredIn = null;
     // filtered data that has been grouped
     this.groupedIn = {};
     // grouped data that has been aggregated
@@ -699,7 +699,7 @@ export class DataChunks {
   }
 
   get filtered() {
-    if (this.filteredIn.length) return this.filteredIn;
+    if (this.filteredIn) return this.filteredIn;
     if (Object.keys(this.filters).length === 0) return this.bundles; // no filter, return all
     if (Object.keys(this.facetFns).length === 0) return this.bundles; // no facets, return all
     this.filteredIn = this.filterBundles(this.bundles, this.filters);

--- a/tools/rum/elements/list-facet.js
+++ b/tools/rum/elements/list-facet.js
@@ -255,6 +255,9 @@ export default class ListFacet extends HTMLElement {
         setTimeout(() => { toast.ariaHidden = true; }, 3000);
       });
       this.append(fieldSet);
+    } else {
+      const fieldSet = this.querySelector('fieldset');
+      if (fieldSet) fieldSet.remove();
     }
   }
 

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -147,7 +147,7 @@ function updateDataFacets(filterText, params, checkpoint) {
   dataChunks.addFacet('filter', (bundle) => {
     // this function is also a bit weird, because it takes
     // the filtertext into consideration
-    const fullText = bundle.url + bundle.events.map((e) => e.checkpoint).join(' ');
+    const fullText = `${bundle.url} ${bundle.events.map((e) => e.checkpoint).join(' ')}`;
     const keywords = filterText
       .split(' ')
       .filter((word) => word.length > 2);


### PR DESCRIPTION
In the `filter` input, type `click` and then `clicke`, then `clicked`... The UI start being unresponsive (or at least slower), facets are not emptied and `click` is still the value highlighted.

This PR addresses the 2 aspects:
- make sure we do not recompute the `filtered` data chunks (not computed !== length === 0)
- reset the list-facet if no facet entry
- bonus: fix the filtertext concat (first checkpoint is part of the url)

Applied fix to `rum` and `oversight`.

Test: 
- https://unmatched-filter--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=www.adobe.com&filter=&view=week&domainkey=incognito
- https://unmatched-filter--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=www.adobe.com&filter=&view=week&domainkey=incognito