### PR TITLE
fix(rum-explorer): allow special domains (not url)

### DIFF
--- a/tools/oversight/elements/url-selector.js
+++ b/tools/oversight/elements/url-selector.js
@@ -62,16 +62,17 @@ export default class URLSelector extends HTMLElement {
     });
 
     this.addEventListener('submit', (event) => {
+      let domain = event.detail;
       try {
-        const entered = new URL(`https://${event.detail}`);
-        const goto = new URL(window.location.pathname, window.location.origin);
-        goto.searchParams.set('domain', entered.hostname);
-        goto.searchParams.set('view', 'month');
-        window.location.href = goto.href;
+        const entered = new URL(`https://${domain}`);
+        domain = entered.hostname;
       } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error('Invalid URL', e, event.detail);
+        // ignore, some domains are not valid URLs
       }
+      const goto = new URL(window.location.pathname, window.location.origin);
+      goto.searchParams.set('domain', domain);
+      goto.searchParams.set('view', 'month');
+      window.location.href = goto.href;
     });
   }
 

--- a/tools/rum/elements/url-selector.js
+++ b/tools/rum/elements/url-selector.js
@@ -62,15 +62,17 @@ export default class URLSelector extends HTMLElement {
     });
 
     this.addEventListener('submit', (event) => {
+      let domain = event.detail;
       try {
-        const entered = new URL(`https://${event.detail}`);
-        const goto = new URL(window.location.pathname, window.location.origin);
-        goto.searchParams.set('domain', entered.hostname);
-        goto.searchParams.set('view', 'month');
-        window.location.href = goto.href;
+        const entered = new URL(`https://${domain}`);
+        domain = entered.hostname;
       } catch (e) {
-        console.error('Invalid URL', e, event.detail);
+        // ignore, some domains are not valid URLs
       }
+      const goto = new URL(window.location.pathname, window.location.origin);
+      goto.searchParams.set('domain', domain);
+      goto.searchParams.set('view', 'month');
+      window.location.href = goto.href;
     });
   }
 


### PR DESCRIPTION
`aem.live:all` is a special org domain but it cannot be entered via the UI.

Test: https://allow-special-domains--helix-website--adobe.hlx.live/tools/rum/explorer.html?domain=aem.live%3Aall&view=month&domainkey=