### PR TITLE
feat(rum-explorer): ui tweaks

### DIFF
--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -98,9 +98,11 @@ main .title {
 main .title url-selector {
   margin-top: 8px;
   margin-bottom: 8px;
+  margin-right: 8px;
   font-size: var(--type-heading-m-size);
   display: flex;
   align-items: center;
+  width: 100%;
 }
 
 main .title url-selector img {

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -98,9 +98,11 @@ main .title {
 main .title url-selector {
   margin-top: 8px;
   margin-bottom: 8px;
+  margin-right: 8px;
   font-size: var(--type-heading-m-size);
   display: flex;
   align-items: center;
+  width: 100%;
 }
 
 main .title url-selector img {

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -713,9 +713,8 @@ vitals-facet fieldset label {
   position: relative;
   display: inline-block;
   transform: scale(1);
-  width: 18px;
-  height: 18px;
-  border: 2px solid;
+  width: 22px;
+  height: 22px;
   border-radius: 2px;
   cursor: pointer;
   overflow: hidden;
@@ -740,11 +739,11 @@ vitals-facet fieldset label {
   box-sizing: border-box;
   position: absolute;
   border-radius: 2px;
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border: 2px solid;
-  top: 4px;
-  left: 4px;
+  top: 8px;
+  left: 8px;
 }
 
 .clipboard::after {
@@ -753,13 +752,13 @@ vitals-facet fieldset label {
   box-sizing: border-box;
   position: absolute;
   border-radius: 2px;
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border: 2px solid;
   border-bottom: 0;
   border-right: 0;
-  top: 1px;
-  left: 1px;
+  top: 5px;
+  left: 5px;
 }
 
 /* toasts */


### PR DESCRIPTION
- url selector to full width (`experienceleague.adobe.com` does not fit the box at the moment)
- reshape the copy icon
- 

Test: : https://ui-tweaks--helix-website--adobe.hlx.live/tools/rum/explorer.html?domain=experienceleague.adobe.com&view=month&domainkey=