### PR TITLE
fix(rum-explorer): media are the same

### DIFF
--- a/tools/rum/elements/file-facet.js
+++ b/tools/rum/elements/file-facet.js
@@ -5,9 +5,9 @@ import ListFacet from './list-facet.js';
  * A custom HTML element to display a list of facets with literal
  * values. If a placeholder has been provided, then the explanation
  * will be shown after the literal value.
- * <literal-facet facet="viewmedia.source" mode="all">
+ * <file-facet facet="viewmedia.source" mode="all">
  *   <legend>Media Source</legend>
- * </literal-facet>
+ * </file-facet>
  */
 export default class FileFacet extends ListFacet {
   // eslint-disable-next-line class-methods-use-this

--- a/tools/rum/elements/file-facet.js
+++ b/tools/rum/elements/file-facet.js
@@ -1,0 +1,17 @@
+import { escapeHTML } from '../utils.js';
+import ListFacet from './list-facet.js';
+
+/**
+ * A custom HTML element to display a list of facets with literal
+ * values. If a placeholder has been provided, then the explanation
+ * will be shown after the literal value.
+ * <literal-facet facet="viewmedia.source" mode="all">
+ *   <legend>Media Source</legend>
+ * </literal-facet>
+ */
+export default class FileFacet extends ListFacet {
+  // eslint-disable-next-line class-methods-use-this
+  createLabelHTML(labelText) {
+    return `<span class="filename">${escapeHTML(labelText)}</span>`;
+  }
+}

--- a/tools/rum/elements/thumbnail-facet.js
+++ b/tools/rum/elements/thumbnail-facet.js
@@ -15,8 +15,15 @@ export default class ThumbnailFacet extends ListFacet {
   // eslint-disable-next-line class-methods-use-this
   createLabelHTML(labelText) {
     const fileName = labelText.split('/').pop().replace(/\?.*/, '');
-    if (labelText.startsWith('https://') && labelText.includes('media_')) {
-      return `<img src="${labelText}?width=750&format=webply&optimize=medium" title="${escapeHTML(labelText)}"><span class="filename">${escapeHTML(fileName)}</span>`;
+    const isMediaStr = labelText.startsWith('media_');
+    if ((labelText.startsWith('https://') && labelText.includes('media_')) || isMediaStr) {
+      let src = labelText;
+      if (isMediaStr) {
+        const domain = new URL(window.location.href).searchParams.get('domain');
+        // cannot work in all cases (context path...), but good enough for now
+        src = `https://${domain}/${labelText}`;
+      }
+      return `<img src="${src}?width=750&format=webply&optimize=medium" title="${escapeHTML(labelText)}"><span class="filename">${escapeHTML(fileName)}</span>`;
     } if (labelText.startsWith('http') && labelText.match(/\.(jpeg|jpg|gif|png|svg|webp)$/)) {
       return `<img src="${labelText}" title="${escapeHTML(labelText)}"><span class="filename">${escapeHTML(fileName)}</span>`;
     }

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -19,6 +19,7 @@
     import LinkFacet from './elements/link-facet.js';
     import LiteralFacet from './elements/literal-facet.js';
     import VitalsFacet from './elements/vitals-facet.js';
+    import FileFacet from './elements/file-facet.js';
     import URLSelector from './elements/url-selector.js';
     window.slicer = {
       Chart: SkylineChart,
@@ -30,6 +31,7 @@
     customElements.define('link-facet', LinkFacet);
     customElements.define('literal-facet', LiteralFacet);
     customElements.define('vitals-facet', VitalsFacet);
+    customElements.define('file-facet', FileFacet);
     customElements.define('url-selector', URLSelector);
   </script>
   <script src="./slicer.js" type="module"></script>
@@ -173,9 +175,9 @@
             <literal-facet facet="viewmedia.source">
               <legend>Media Source (CSS Selector)</legend>
             </literal-facet>
-            <thumbnail-facet facet="viewmedia.target">
+            <file-facet facet="viewmedia.target">
               <legend>Media Target</legend>
-            </thumbnail-facet>
+            </file-facet>
             <literal-facet facet="viewblock.source">
               <legend>Block (CSS Selector)</legend>
             </literal-facet>

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -549,6 +549,38 @@ thumbnail-facet label span.count {
   min-width: 54px;
 }
 
+file-facet label {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+
+file-facet fieldset div:not(.more-container) {
+  border-bottom: 1px solid currentcolor;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+file-facet label > span {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+file-facet label span.filename {
+  font-family: monospace;
+  font-size: 80%;
+  background-color: var(--spectrum-blue-200);
+  border: 1px solid var(--spectrum-blue-400);
+  padding: 2px 4px;
+  line-height: 1.4;
+  margin-left: 4px;
+}
+
+file-facet label span.count {
+  min-width: 54px;
+}
+
 vitals-facet fieldset {
   display: grid;
   grid-template-areas:

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -180,7 +180,15 @@ function updateDataFacets(filterText, params, checkpoint) {
           bundle.events
             .filter((evt) => evt.checkpoint === cp)
             .filter(({ target }) => target) // filter out empty targets
-            .reduce((acc, { target }) => { acc.add(target); return acc; }, new Set()),
+            .reduce((acc, { target }) => {
+              const mi = target.indexOf('/media_');
+              if (mi) {
+                acc.add(target.substring(mi + 1));
+              } else {
+                acc.add(target);
+              }
+              return acc;
+            }, new Set()),
         ));
 
         if (cp === 'loadresource') {

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -182,7 +182,7 @@ function updateDataFacets(filterText, params, checkpoint) {
             .filter(({ target }) => target) // filter out empty targets
             .reduce((acc, { target }) => {
               const mi = target.indexOf('/media_');
-              if (mi) {
+              if (cp === 'viewmedia' && mi) {
                 acc.add(target.substring(mi + 1));
               } else {
                 acc.add(target);

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -181,9 +181,13 @@ function updateDataFacets(filterText, params, checkpoint) {
             .filter((evt) => evt.checkpoint === cp)
             .filter(({ target }) => target) // filter out empty targets
             .reduce((acc, { target }) => {
-              const mi = target.indexOf('/media_');
-              if (cp === 'viewmedia' && mi) {
-                acc.add(target.substring(mi + 1));
+              if (typeof target === 'string') {
+                const mi = target.indexOf('/media_');
+                if (cp === 'viewmedia' && mi) {
+                  acc.add(target.substring(mi + 1));
+                } else {
+                  acc.add(target);
+                }
               } else {
                 acc.add(target);
               }


### PR DESCRIPTION
`media_x` is rendered relative to the current page, which means the same image might be rendered with different paths. Those new to be grouped together in the Media Target facet.

Showing the thumbnail then becomes problematic (one of those should be shown or root one cannot be used but it does not work in all the cases). More generally, thumbnails are useless, rendered stretched and overload the UI (might also lead to be blocked by remote host). This PR adds a File Facet to only show the filename.

Test: https://media-facet--helix-website--adobe.hlx.live/tools/rum/explorer.html?domain=www.bamboohr.com&view=month&domainkey=