### PR TITLE
feat: host type facet

### DIFF
--- a/tools/rum/cruncher.js
+++ b/tools/rum/cruncher.js
@@ -21,6 +21,7 @@
  * @property {string} timeSlot - the hourly timesot that this bundle belongs to
  * @property {string} url - the URL of the request, without URL parameters
  * @property {string} userAgent - the user agent class, for instance desktop:windows or mobile:ios
+ * @property {string} hostType - the type of host, for instance 'helix' or 'aemcs'
  * @property {number} weight - the weight, or sampling ratio 1:n of the bundle
  * @property {RawEvent} events - the list of events that make up the bundle
  */

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -105,6 +105,9 @@
             </figure>
           </div>
           <facet-sidebar>
+            <list-facet facet="type">
+              <legend>Host Type</legend>
+            </list-facet>
             <list-facet facet="userAgent">
               <legend>Device Type and Operating System</legend>
               <dl>

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -104,6 +104,9 @@ export function updateKeyMetrics(keyMetrics) {
 
 function updateDataFacets(filterText, params, checkpoint) {
   dataChunks.resetFacets();
+
+  dataChunks.addFacet('type', (bundle) => bundle.hostType);
+
   dataChunks.addFacet(
     'conversions',
     (bundle) => (dataChunks.hasConversion(bundle, conversionSpec) ? 'converted' : 'not-converted'),

--- a/tools/rum/utils.js
+++ b/tools/rum/utils.js
@@ -9,6 +9,7 @@ export function isKnownFacet(key) {
   return false // TODO: find a better way to filter out non-facet keys
     || key === 'userAgent'
     || key === 'url'
+    || key === 'type'
     || key === 'conversions'
     // facets from sankey
     || key === 'trafficsource'


### PR DESCRIPTION
Adds new Host Type facet.

Test:
- Facet is enabled: https://host-type--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=aem.live:all&filter=&view=week&domainkey=
- Facet is disabled: https://host-type--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=aem.live:all&filter=&view=week&domainkey=