### PR TITLE
feat(rum-oversight): host type facet

### DIFF
--- a/tools/oversight/cruncher.js
+++ b/tools/oversight/cruncher.js
@@ -21,6 +21,7 @@
  * @property {string} timeSlot - the hourly timesot that this bundle belongs to
  * @property {string} url - the URL of the request, without URL parameters
  * @property {string} userAgent - the user agent class, for instance desktop:windows or mobile:ios
+ * @property {string} hostType - the type of host, for instance 'helix' or 'aemcs'
  * @property {number} weight - the weight, or sampling ratio 1:n of the bundle
  * @property {RawEvent} events - the list of events that make up the bundle
  */

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -107,6 +107,9 @@
             </figure>
           </div>
           <facet-sidebar>
+            <list-facet facet="type">
+              <legend>Host Type</legend>
+            </list-facet>
             <list-facet facet="userAgent" drilldown="share.html">
               <legend>Device Type and Operating System</legend>
               <dl>

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -143,6 +143,9 @@ export function updateKeyMetrics() {
 
 function updateDataFacets(filterText, params, checkpoint) {
   dataChunks.resetFacets();
+
+  dataChunks.addFacet('type', (bundle) => bundle.hostType);
+
   dataChunks.addFacet(
     'conversions',
     (bundle) => (dataChunks.hasConversion(bundle, conversionSpec) ? 'converted' : 'not-converted'),

--- a/tools/oversight/utils.js
+++ b/tools/oversight/utils.js
@@ -12,6 +12,7 @@ export function isKnownFacet(key) {
   return false // TODO: find a better way to filter out non-facet keys
     || key === 'userAgent'
     || key === 'url'
+    || key === 'type'
     || key === 'conversions'
     // facets from sankey
     || key === 'trafficsource'


### PR DESCRIPTION
Oversight version of #621.

@trieloff No need for extra capability: either hostType is provided for the `aem.live:all` domain or it is not, i.e. no entry at all, facet is then not visible.


Test:

Facet is enabled: https://host-type-lab--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=aem.live:all&filter=&view=week&domainkey=
Facet is disabled: https://host-type-lab--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=aem.live:all&filter=&view=week&domainkey=