### PR TITLE
feat(rum-oversight): split draw from loadData

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -344,8 +344,6 @@ async function loadData(scope, chart) {
   } else if (scope === 'year') {
     dataChunks.load(await loader.fetchPrevious12Months(endDate));
   }
-
-  draw();
 }
 
 export function updateState() {
@@ -411,7 +409,7 @@ const io = new IntersectionObserver((entries) => {
     elems.incognito.addEventListener('change', async () => {
       loader.domainKey = elems.incognito.getAttribute('domainkey');
       await loadData(view, herochart);
-      herochart.draw();
+      draw();
     });
 
     herochart.render();
@@ -425,7 +423,7 @@ const io = new IntersectionObserver((entries) => {
     elems.timezoneElement.textContent = timezone;
 
     if (elems.incognito.getAttribute('domainkey')) {
-      loadData(view, herochart);
+      loadData(view, herochart).then(draw);
     }
 
     elems.filterInput.addEventListener('input', () => {


### PR DESCRIPTION
Currently, the loadData method is calling draw at the end. This causes some duplicated call to the draw method of the chart - it doesn't really seem to be a performance problem (nor cause other issues) but it seems it would make some sense to move the draw call out of loadData and invoke it explicitly when needed. 

Test: https://slicerdraw--helix-website--karlpauls.hlx.page/tools/oversight/explorer.html?domain=aem.live&domainkey=