### PR TITLE
feat(rum-oversight): improve get totals by replacing a reduce with a copy

### DIFF
--- a/tools/oversight/cruncher.js
+++ b/tools/oversight/cruncher.js
@@ -106,12 +106,16 @@ function groupFn(groupByFn) {
  * @typedef {Object} Aggregate - an object that contains aggregate metrics
  */
 class Aggregate {
-  constructor(parent = null) {
+  constructor(parentProvider = () => null) {
     this.count = 0;
     this.sum = 0;
     this.weight = 0;
     this.values = [];
-    this.parent = parent;
+    this.parentProvider = parentProvider;
+  }
+
+  get parent() {
+    return this.parentProvider();
   }
 
   get min() {
@@ -802,7 +806,7 @@ export class DataChunks {
               aggregateFn(valueFn),
               // we reference the totals object here, so that we can
               // calculate the share and percentage metrics
-              new Aggregate(this.totals[seriesName]),
+              new Aggregate(() => this.totals[seriesName]),
             );
             return accInner;
           }, {});
@@ -848,20 +852,17 @@ export class DataChunks {
     // go over each function in this.series and each value in filteredIn
     // and appy the function to the value
     if (Object.keys(this.totalsIn).length) return this.totalsIn;
-    const parentTotals = Object.entries(this.series)
+    this.totalsIn = Object.entries(this.series)
       .reduce((acc, [seriesName, valueFn]) => {
-        acc[seriesName] = this.filtered.reduce(
+        const parent = this.filtered.reduce(
           aggregateFn(valueFn),
           new Aggregate(),
         );
-        return acc;
-      }, {});
-    this.totalsIn = Object.entries(this.series)
-      .reduce((acc, [seriesName, valueFn]) => {
-        acc[seriesName] = this.filtered.reduce(
-          aggregateFn(valueFn),
-          new Aggregate(parentTotals[seriesName]),
-        );
+        // we need to clone the aggregate object, so that we can use it as its own parent
+        // this is necessary for calculating the share and percentage metrics
+        // the alternative would be to calculate the totals for each group twice (which is slower)
+        acc[seriesName] = Object.assign(Object.create(Object.getPrototypeOf(parent)), parent);
+        acc[seriesName].parentProvider = () => parent;
         return acc;
       }, {});
     return this.totalsIn;


### PR DESCRIPTION
Improve the performance of get totals in cruncher.

## Description

The get totals can be delayed a bit in certain cases and it right now does a reduce over all bundles twice (one time to calculate the parent). It seem possible to replace that with copying the result of the first result and use the copy as the parent.

## Motivation and Context

Speed improvements

## How Has This Been Tested?

Looking at the ui rendering speed in the console at https://totals--helix-website--karlpauls.hlx.page/tools/oversight/explorer.html?domain=aem.live&domainkey=
