### PR TITLE
feat(rum-oversight): improve applyFilter

### DIFF
--- a/tools/oversight/cruncher.js
+++ b/tools/oversight/cruncher.js
@@ -692,14 +692,11 @@ export class DataChunks {
       .filter(skipFilterFn)
       .filter(([, desiredValues]) => desiredValues.length)
       .filter(existenceFilterFn);
-    return bundles.filter((bundle) => {
-      const matches = filterBy.map(([attributeName, desiredValues]) => {
-        const actualValues = valuesExtractorFn(attributeName, bundle, this);
-        const combiner = combinerExtractorFn(attributeName, this);
-        return desiredValues[combiner]((value) => actualValues.includes(value));
-      });
-      return matches.every((match) => match);
-    });
+    return bundles.filter((bundle) => filterBy.every(([attributeName, desiredValues]) => {
+      const actualValues = valuesExtractorFn(attributeName, bundle, this);
+      const combiner = combinerExtractorFn(attributeName, this);
+      return desiredValues[combiner]((value) => actualValues.includes(value));
+    }));
   }
 
   /**


### PR DESCRIPTION
Save a loop in the applyFilter method of cruncher (as applyFilter is getting called a lot).

## Description

The applyFilter method is called a lot and it seems to iterate over a result list to see if every value is true which it looks like could be done directly.

## Motivation and Context

Speed-up the applyFilter method

## How Has This Been Tested?

Looking at the ui rendering speed timing in the console at:

https://filter--helix-website--karlpauls.hlx.page/tools/oversight/explorer.html?domain=aem.live&domainkey=

