### PR TITLE
feat(rum-oversight): improve matching in consent

### DIFF
--- a/tools/oversight/consent.js
+++ b/tools/oversight/consent.js
@@ -1,37 +1,56 @@
-const vendors = {
-  onetrust: {
-    match: /#(onetrust|ot)-/,
+const vendors = [
+  {
+    vendor: 'onetrust',
+    match: /#onetrust-/,
     accept: /accept/,
     reject: /reject/,
     dismiss: /close-pc-btn-handler/,
   },
-  usercentrics: {
+  {
+    vendor: 'onetrust',
+    match: /#ot-/,
+    accept: /accept/,
+    reject: /reject/,
+    dismiss: /close-pc-btn-handler/,
+  },
+  {
+    vendor: 'usercentrics',
     match: /#usercentrics-root/,
     // we don't have nicely id'd buttons here
   },
-  truste: {
+  {
+    vendor: 'truste',
     match: /#truste/,
     accept: /consent-button/,
     dismiss: /close/,
   },
-  cybot: {
+  {
+    vendor: 'cybot',
     match: /#CybotCookiebot/,
     accept: /AllowAll/,
     reject: /Decline/,
   },
-};
+];
 
+class Consent {
+  constructor(vendor, spec, cssSelector) {
+    this.checkpoint = 'consent';
+    this.vendor = vendor;
+    this.spec = spec;
+    this.cssSelector = cssSelector;
+  }
+
+  get target() {
+    return Object.entries(this.spec)
+      .filter(([key]) => key !== 'match' && key !== 'vendor')
+      .filter(([, pattern]) => pattern.test(this.cssSelector))
+      .map(([key]) => key)
+      .pop();
+  }
+}
 export default function classifyConsent(cssSelector) {
-  return cssSelector
-    && (Object.entries(vendors)
-      .filter(([, { match }]) => match.test(cssSelector))
-      .map(([vendor, spec]) => ({
-        checkpoint: 'consent',
-        source: vendor,
-        target: Object.entries(spec)
-          .filter(([key]) => key !== 'match')
-          .filter(([, pattern]) => pattern.test(cssSelector))
-          .map(([key]) => key)
-          .pop(),
-      }))).pop();
+  if (!cssSelector) return undefined;
+  const result = vendors.find(({ match }) => match.test(cssSelector));
+  if (result) return new Consent(result.vendor, result, cssSelector);
+  return undefined;
 }


### PR DESCRIPTION
The matching in consent maps over all possibilities. Replacing it with find can shortcut the evaluation as only one match is required.

## Description

Replace the map in consent with a find and delay the actual look up of the target. 

## Motivation and Context

Trying to improve the speed of consent matching.

## How Has This Been Tested?

Looking at the ui rendering speed in the console at 
https://consentmatching--helix-website--karlpauls.hlx.page/tools/oversight/explorer.html?domain=aem.live&domainkey=

