### PR TITLE
feat(rum-oversight): unroll scoreCWV loop in util

### DIFF
--- a/tools/oversight/utils.js
+++ b/tools/oversight/utils.js
@@ -2,11 +2,6 @@ import classifyConsent from './consent.js';
 import { classifyAcquisition } from './acquisition.js';
 
 /* helpers */
-export function scoreValue(value, ni, poor) {
-  if (value >= poor) return 'poor';
-  if (value >= ni) return 'ni';
-  return 'good';
-}
 
 export function isKnownFacet(key) {
   return false // TODO: find a better way to filter out non-facet keys
@@ -32,14 +27,34 @@ export function isKnownFacet(key) {
 
 export function scoreCWV(value, name) {
   if (value === undefined || value === null) return null;
-  const limits = {
-    lcp: [2500, 4000],
-    cls: [0.1, 0.25],
-    inp: [200, 500],
-    ttfb: [800, 1800],
-  };
-  return scoreValue(value, ...limits[name]);
+  let poor;
+  let ni;
+  // this is unrolled on purpose as this method becomes a bottleneck
+  if (name === 'lcp') {
+    poor = 4000;
+    ni = 2500;
+  }
+  if (name === 'cls') {
+    poor = 0.25;
+    ni = 0.1;
+  }
+  if (name === 'inp') {
+    poor = 500;
+    ni = 200;
+  }
+  if (name === 'ttfb') {
+    poor = 1800;
+    ni = 800;
+  }
+  if (value >= poor) {
+    return 'poor';
+  }
+  if (value >= ni) {
+    return 'ni';
+  }
+  return 'good';
 }
+
 export const UA_KEY = 'userAgent';
 
 /**
@@ -329,7 +344,7 @@ export function reclassifyEnter(acc, event, i, allEvents) {
     // we need to reclassify when we have seen both enter and acquisition
     (event.checkpoint === 'enter' || event.checkpoint === 'acquisition')
     // but if there is no acquisition, we reclassify the enter event
-    && ((!has('acquisition')) || (acc.acquisition && acc.referrer))) {
+    && ((acc.acquisition && acc.referrer) || (!has('acquisition')))) {
     const [aGroup, aCategory, aVendor] = (acc.acquisition || '').split(':');
     const [, rCategory, rVendor] = (classifyAcquisition(acc.referrer) || '').split(':');
     const group = aGroup || 'earned';


### PR DESCRIPTION
The scoreCWV method is using a loop that can be unrolled to improve performance (as it doesn't gc as much)

## Description

Since the method gets very hot, it seems to produce less gc if it doesn't keep creating a list for the values (the code looks a little more verbose).

## Motivation and Context

Speedup the scoreCWV method

## How Has This Been Tested?

Looking at the ui rendering speed in the console at

https://utilunroll--helix-website--karlpauls.hlx.page/tools/oversight/explorer.html?domain=aem.live&domainkey=