### PR TITLE
feat(rum-oversight): use find instead of reduce in acquisition

### DIFF
--- a/tools/oversight/acquisition.js
+++ b/tools/oversight/acquisition.js
@@ -114,32 +114,21 @@ const categoryTypeLookup = {
 };
 
 export function vendor(origin) {
-  return vendorClassifications
-    .reduce((result, classification) => (
-      !result && classification.regex.test(origin)
-        ? classification.result
-        : result), '');
+  const result = vendorClassifications.find(({ regex }) => regex.test(origin));
+  return result ? result.result : '';
 }
 
 function category(origin, vendorResult) {
-  const categoryResult = categoryClassifications
-    .reduce((result, classification) => (
-      !result && classification.regex.test(origin)
-        ? classification.result
-        : result), '');
+  const categoryResult = categoryClassifications.find(({ regex }) => regex.test(origin));
 
-  if (categoryResult) return categoryResult;
+  if (categoryResult) return categoryResult.result;
   return vendorCategoryLookup[vendorResult] || '';
 }
 
 function paidowned(origin, vendorResult, categoryResult) {
-  const paidOwnedResult = paidOwnedClassifications
-    .reduce((result, classification) => (
-      !result && classification.regex.test(origin)
-        ? classification.result
-        : result), '');
+  const paidOwnedResult = paidOwnedClassifications.find(({ regex }) => regex.test(origin));
 
-  if (paidOwnedResult) return paidOwnedResult;
+  if (paidOwnedResult) return paidOwnedResult.result;
   return vendorTypeLookup[vendorResult] || categoryTypeLookup[categoryResult] || '';
 }
 


### PR DESCRIPTION
Use find instead of reduce in acquisition to shortcut evaluation.

## Description

It seems like we can use find instead of reduce in acquisitions to shortcut the search.

## Motivation and Context

Speedup the acquisition evaluation.

## How Has This Been Tested?

Looking at the ui rendering speed in the console at 

https://acquisitionreduce--helix-website--karlpauls.hlx.page/tools/oversight/explorer.html?domain=aem.live&domainkey=
