### PR TITLE
Support Negative URL Facet

### DIFF
--- a/tools/oversight/cruncher.js
+++ b/tools/oversight/cruncher.js
@@ -431,6 +431,7 @@ export class DataChunks {
 
   resetFacets() {
     this.facetFns = {};
+    this.facetCombiners = {};
   }
 
   /**
@@ -442,7 +443,7 @@ export class DataChunks {
    */
   addFacet(facetName, facetValueFn, facetCombiner = 'some') {
     this.facetFns[facetName] = facetValueFn;
-    this.facetFns[facetName].combiner = facetCombiner;
+    this.facetCombiners[facetName] = facetCombiner;
     this.resetData();
   }
 
@@ -673,7 +674,7 @@ export class DataChunks {
       const facetValue = parent.facetFns[attributeName](bundle);
       return Array.isArray(facetValue) ? facetValue : [facetValue];
     };
-    const combinerExtractorFn = (attributeName, parent) => parent.facetFns[attributeName].combiner || 'some';
+    const combinerExtractorFn = (attributeName, parent) => parent.facetCombiners[attributeName] || 'some';
     // eslint-disable-next-line max-len
     return this.applyFilter(bundles, filterSpec, skipFilterFn, existenceFilterFn, valuesExtractorFn, combinerExtractorFn);
   }
@@ -919,7 +920,7 @@ export class DataChunks {
           .filterBundles(
             this.bundles,
             this.filters,
-            this.facetFns[facetName].combiner === 'some'
+            this.facetCombiners[facetName] === 'some'
               ? [facetName]
               : [],
           )

--- a/tools/oversight/elements/list-facet.js
+++ b/tools/oversight/elements/list-facet.js
@@ -224,7 +224,12 @@ export default class ListFacet extends HTMLElement {
           input.id = `${facetName}=${entry.value}`;
           if (enabled) {
             div.addEventListener('click', (evt) => {
-              if (evt.target !== input) input.checked = !input.checked;
+              if (!evt.shiftKey && evt.target !== input) {
+                input.checked = !input.checked;
+              } else if (evt.shiftKey) {
+                // use the shift key to indicate a negation
+                input.indeterminate = true;
+              }
               evt.stopPropagation();
               this.parentElement.parentElement.dispatchEvent(new Event('facetchange'), this);
             });

--- a/tools/oversight/elements/list-facet.js
+++ b/tools/oversight/elements/list-facet.js
@@ -221,6 +221,10 @@ export default class ListFacet extends HTMLElement {
             // addFilterTag(facetName, entry.value);
             div.ariaSelected = true;
           }
+          input.indeterminate = url.searchParams.getAll(`${facetName}!`).includes(entry.value);
+          if (input.indeterminate) {
+            div.ariaChecked = 'mixed';
+          }
           input.id = `${facetName}=${entry.value}`;
           if (enabled) {
             div.addEventListener('click', (evt) => {

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -736,6 +736,11 @@ vitals-facet fieldset label {
   background-color: var(--light-blue)
 }
 
+#facets div[aria-checked=mixed] {
+  opacity: 0.7;
+  filter: brightness(0.7);
+}
+
 #facets div[aria-selected]:hover {
   background-color: #eee;
 }

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -158,7 +158,8 @@ function updateDataFacets(filterText, params, checkpoint) {
       return acc;
     }, []);
   });
-  dataChunks.addFacet('url', (bundle) => {
+
+  const urlFn = (bundle) => {
     if (bundle.domain) return bundle.domain;
     const u = new URL(bundle.url);
     u.pathname = u.pathname.split('/')
@@ -186,7 +187,9 @@ function updateDataFacets(filterText, params, checkpoint) {
         return segment;
       }).join('/');
     return u.toString();
-  });
+  };
+  dataChunks.addFacet('url', urlFn);
+  dataChunks.addFacet('url!', urlFn, 'none');
 
   dataChunks.addFacet('vitals', (bundle) => {
     const cwv = ['cwvLCP', 'cwvCLS', 'cwvINP'];

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -189,7 +189,7 @@ function updateDataFacets(filterText, params, checkpoint) {
     return u.toString();
   };
   dataChunks.addFacet('url', urlFn);
-  dataChunks.addFacet('url!', urlFn, 'none');
+  dataChunks.addFacet('url!', urlFn, 'never');
 
   dataChunks.addFacet('vitals', (bundle) => {
     const cwv = ['cwvLCP', 'cwvCLS', 'cwvINP'];
@@ -364,7 +364,9 @@ export function updateState() {
   if (drilldown) url.searchParams.set('drilldown', drilldown);
 
   elems.sidebar.querySelectorAll('input').forEach((e) => {
-    if (e.checked) {
+    if (e.indeterminate) {
+      url.searchParams.append(`${e.id.split('=')[0]}!`, e.value);
+    } else if (e.checked) {
       url.searchParams.append(e.id.split('=')[0], e.value);
     }
   });

--- a/tools/oversight/utils.js
+++ b/tools/oversight/utils.js
@@ -7,6 +7,7 @@ export function isKnownFacet(key) {
   return false // TODO: find a better way to filter out non-facet keys
     || key === 'userAgent'
     || key === 'url'
+    || key === 'url!'
     || key === 'type'
     || key === 'conversions'
     // facets from sankey


### PR DESCRIPTION
as of now, this PR does not come with a UI, and it is only limited to the URL facet. You can try it
by appending `&url!=https://examplehost.com/examplepath` – this will then exclude that particular URL
from all results shown in the UI. I haven't tried what happens when you combine this with the opposite,
but my expectation is that you end up with an empty set, as different facets are combined with AND.

The PR also adds a `never` combiner option to factets, enforcing that every single facet value must
not satisfy the facet conditions.
