### PR TITLE
chore(rum): display fix for favicon for aggregates with `:`

### DIFF
--- a/tools/rum/elements/url-selector.js
+++ b/tools/rum/elements/url-selector.js
@@ -37,7 +37,7 @@ export default class URLSelector extends HTMLElement {
     const input = this.querySelector('input');
     input.value = new URL(window.location.href).searchParams.get('domain');
     const img = this.querySelector('img');
-    img.src = `https://www.google.com/s2/favicons?domain=${input.value}&sz=64`;
+    img.src = `https://www.google.com/s2/favicons?domain=${input.value.split(':')[0]}&sz=64`;
 
     if (!getPersistentToken()) {
       input.disabled = true;


### PR DESCRIPTION
https://www.aem.live/tools/rum/explorer.html?domain=test.com%3Aall

vs.

https://rum-icon-fix--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=test.com%3Aall