### PR TITLE
feat(oversight): show that iOS CWVs are fake

### DIFF
--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -187,6 +187,12 @@ main facet-sidebar ul.cwv > li[title^="INP"] number-format::after {
   content: 's';
 }
 
+/* as of 2024, all iOS CWV values are fake, so we hide them a bit */
+main facet-sidebar input[value="mobile:ios"] ~ ul.cwv {
+  opacity: 0.5;
+  filter: grayscale(1);
+}
+
 main .key-metrics ul > #lcp number-format.extra::after {
   content: 's caused by TTFB)'
 }


### PR DESCRIPTION
As of 2024, CWV readings with iOS user agents are coming from non-iOS browsers
that falsify their user agent string. This can include Chrome when using devtools
and simulating a mobile viewport. Apple does not allow custom rendering engines
in most of the world, and in the EU, where it does allow custom rendering engines,
no browser vendor ships a browser with a non-WebKit engine, so that all actual
iOS browsers are just WebKit in disguise. Webkit does not implement key APIs required
for measurement of Core Web Vitals, effectively rendering all CWVs readings that
claim to apply to iOS suspect.

This PR addresses this by reducing the visual contrast of the CWV pills for the
user agent iOS only.

<img width="1030" alt="Screenshot 2024-09-09 at 09 55 18" src="https://github.com/user-attachments/assets/1dcb38b7-d13b-4414-8b45-706fa5538777">

