### PR TITLE
Preserve facet expansion

### DIFF
--- a/tools/oversight/elements/list-facet.js
+++ b/tools/oversight/elements/list-facet.js
@@ -114,7 +114,7 @@ export default class ListFacet extends HTMLElement {
     const url = new URL(window.location);
     const drilldownAtt = this.getAttribute('drilldown');
     const mode = url.searchParams.get('mode') || this.getAttribute('mode');
-    const numOptions = mode === 'all' ? 20 : 10;
+    const numOptions = parseInt(url.searchParams.get(`${facetName}~`), 10) || 10;
 
     if (this.querySelector('dl')) {
       this.placeholders = Array.from(this.querySelectorAll('dl > dt + dd'))
@@ -318,12 +318,15 @@ export default class ListFacet extends HTMLElement {
         const div = document.createElement('div');
         div.className = 'load-more';
         const more = document.createElement('label');
-        more.textContent = 'more...';
+        more.textContent = 'more…';
         more.addEventListener('click', (evt) => {
           evt.preventDefault();
           const start = fieldSet.children.length - 2; // minus the "legend" and "more" container
           const end = start + numOptions;
           paint(start, end);
+          const usp = new URLSearchParams(window.location.search);
+          usp.set(`${facetName}~`, end);
+          window.history.pushState({}, '', `${window.location.pathname}?${usp}`);
 
           if (end >= filteredKeys.length) {
             container.remove();

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -381,6 +381,14 @@ export function updateState() {
     });
   });
 
+  // iterate over all existing URL parameters and keep those that are known facets
+  // and end with ~, so that we can keep the state of the facets
+  searchParams.forEach((value, key) => {
+    if (key.endsWith('~') && isKnownFacet(key)) {
+      url.searchParams.set(key, value);
+    }
+  });
+
   window.history.replaceState({}, '', url);
   document.dispatchEvent(new CustomEvent('urlstatechange', { detail: url }));
 }

--- a/tools/oversight/test/utils.test.js
+++ b/tools/oversight/test/utils.test.js
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { truncate, escapeHTML, computeConversionRate } from '../utils.js';
+import {
+  truncate, escapeHTML, computeConversionRate, isKnownFacet,
+} from '../utils.js';
 
 describe('truncate', () => {
   it('truncates to the beginning of the hour', () => {
@@ -71,5 +73,17 @@ describe('computeConversionRate', () => {
   it('its 100% for 2 conversion and 1 visits', () => {
     const result = computeConversionRate(0, 0);
     assert.strictEqual(result, 100);
+  });
+
+  describe('check valid facets', () => {
+    assert.ok(isKnownFacet('userAgent'));
+    assert.ok(!isKnownFacet('browser'));
+
+    assert.ok(isKnownFacet('checkpoint.source'));
+    assert.ok(!isKnownFacet('checkpoint.value'));
+
+    assert.ok(isKnownFacet('url!'));
+    assert.ok(isKnownFacet('url~'));
+    assert.ok(!isKnownFacet('url+'));
   });
 });

--- a/tools/oversight/utils.js
+++ b/tools/oversight/utils.js
@@ -4,27 +4,45 @@ import { classifyAcquisition } from './acquisition.js';
 /* helpers */
 
 export function isKnownFacet(key) {
-  return false // TODO: find a better way to filter out non-facet keys
-    || key === 'userAgent'
-    || key === 'url'
-    || key === 'url!'
-    || key === 'type'
-    || key === 'conversions'
+  const baseFacets = [
+    'userAgent',
+    'url',
+    'type',
+    'conversions',
+    'checkpoint',
     // facets from sankey
-    || key === 'trafficsource'
-    || key === 'traffictype'
-    || key === 'entryevent'
-    || key === 'pagetype'
-    || key === 'loadtype'
-    || key === 'contenttype'
-    || key === 'interaction'
-    || key === 'clicktarget'
-    || key === 'exit'
-    || key === 'vitals'
-    || key.endsWith('.source')
-    || key.endsWith('.target')
-    || key.endsWith('.histogram')
-    || key === 'checkpoint';
+    'trafficsource',
+    'traffictype',
+    'entryevent',
+    'pagetype',
+    'loadtype',
+    'contenttype',
+    'interaction',
+    'clicktarget',
+    'exit',
+    'vitals',
+  ];
+
+  const suffixes = [
+    'source',
+    'target',
+    'histogram',
+  ];
+
+  const modifiers = [
+    '!', // indicates a negation, and allows us to select a negative facet
+    '~', // indicates a count, and allows us to control how many items are shown
+  ];
+
+  const facetPattern = /^(?<facet>[a-z]+)(\.(?<suffix>[a-z]+))?(?<qualifier>[!~])?$/i;
+  const match = facetPattern.exec(key);
+  if (match) {
+    const { facet, suffix, qualifier } = match.groups;
+    return baseFacets.includes(facet)
+      && (!suffix || suffixes.includes(suffix))
+      && (!qualifier || modifiers.includes(qualifier));
+  }
+  return false;
 }
 
 export function scoreCWV(value, name) {


### PR DESCRIPTION
This change will make sure that after clicking "more" in the facet ui, and selecting a value, the facet will remember how far it got expanded. This also prevents obscure facet values from becoming invisible after selecting them.