### PR TITLE
Limit visible lines for description in Feed Block

### DIFF
--- a/blocks/feed/feed.css
+++ b/blocks/feed/feed.css
@@ -50,6 +50,32 @@
   line-height: var(--type-body-s-lh);
 }
 
+.feed.recent .desc {
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  position: relative;
+  margin-bottom: 0;
+}
+
+.feed.recent .desc.expanded {
+  display: block;
+  -webkit-line-clamp: unset;
+}
+
+.feed.recent .read-more {
+  color: var(--tabs-active-color);
+  cursor: pointer;
+  display: inline-block;
+  margin-top: 5px;
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  text-decoration: underline;
+}
+
 @media screen and (min-width: 768px) {
   .feed.recent > div > div {
     grid-template-columns: 1fr 1fr 1fr;

--- a/blocks/feed/feed.css
+++ b/blocks/feed/feed.css
@@ -53,27 +53,10 @@
 .feed.recent .desc {
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
-  -webkit-line-clamp: 6;
+  -webkit-line-clamp: 5;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  position: relative;
-  margin-bottom: 0;
-}
-
-.feed.recent .desc.expanded {
-  display: block;
-  -webkit-line-clamp: unset;
-}
-
-.feed.recent .read-more {
-  color: var(--tabs-active-color);
-  cursor: pointer;
-  display: inline-block;
-  margin-top: 5px;
-  font-size: var(--type-body-xs-size);
-  line-height: var(--type-body-xs-lh);
-  text-decoration: underline;
 }
 
 @media screen and (min-width: 768px) {

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -25,6 +25,28 @@ export async function renderFeed(block) {
     const desc = createTag('p', { class: 'desc' }, page.Description);
     div.appendChild(desc);
 
+    gridDiv.appendChild(div);
+
+    requestAnimationFrame(() => {
+      const lineHeight = parseFloat(getComputedStyle(desc).lineHeight);
+      const maxHeight = lineHeight * 6;
+      const descHeight = desc.scrollHeight;
+
+      if (descHeight > maxHeight) {
+        const readMore = createTag('span', { class: 'read-more' }, 'Read more');
+        readMore.addEventListener('click', () => {
+          if (desc.classList.contains('expanded')) {
+            desc.classList.remove('expanded');
+            readMore.textContent = 'Read more';
+          } else {
+            desc.classList.add('expanded');
+            readMore.textContent = 'Read less';
+          }
+        });
+        desc.insertAdjacentElement('afterend', readMore);
+      }
+    });
+
     const title = createTag('p', { class: 'link' });
     const a = createTag('a', {
       href: page.URL, target: '_blank',

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -25,28 +25,6 @@ export async function renderFeed(block) {
     const desc = createTag('p', { class: 'desc' }, page.Description);
     div.appendChild(desc);
 
-    gridDiv.appendChild(div);
-
-    requestAnimationFrame(() => {
-      const lineHeight = parseFloat(getComputedStyle(desc).lineHeight);
-      const maxHeight = lineHeight * 6;
-      const descHeight = desc.scrollHeight;
-
-      if (descHeight > maxHeight) {
-        const readMore = createTag('span', { class: 'read-more' }, 'Read more');
-        readMore.addEventListener('click', () => {
-          if (desc.classList.contains('expanded')) {
-            desc.classList.remove('expanded');
-            readMore.textContent = 'Read more';
-          } else {
-            desc.classList.add('expanded');
-            readMore.textContent = 'Read less';
-          }
-        });
-        desc.insertAdjacentElement('afterend', readMore);
-      }
-    });
-
     const title = createTag('p', { class: 'link' });
     const a = createTag('a', {
       href: page.URL, target: '_blank',


### PR DESCRIPTION
## Description
This PR addresses limiting the number of lines visible for description of each discord event in Feed Block

## Related Issue
Fix for #646 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Better user experience

## Screenshots (if appropriate):
<img width="398" alt="Screenshot 2024-09-09 at 17 29 57" src="https://github.com/user-attachments/assets/c738ea6a-c695-4193-a8e5-3aa588c62efe">
(Limiting visible content to 5 lines)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

https://main--helix-website--adobe.aem.page/community
vs
https://issue-646--helix-website--adobe.aem.page/community
