### PR TITLE
feat(rum-explorer): domain navigation for orgs

### DIFF
--- a/tools/rum/elements/link-facet.js
+++ b/tools/rum/elements/link-facet.js
@@ -36,12 +36,18 @@ export default class LinkFacet extends ListFacet {
     if (labelText.startsWith('referrer:')) {
       return `<a href="${labelText.replace('referrer:', 'https://')}" target="_new">${labelText.replace('referrer:', '')}</a>`;
     }
+    const currentURL = new URL(window.location.href);
+    const domain = currentURL.searchParams.get('domain');
     if (labelText.startsWith('navigate:')) {
-      const domain = new URL(window.location.href).searchParams.get('domain');
       return `navigate from <a href="${labelText.replace('navigate:', `https://${domain}`)}" target="_new">${labelText.replace('navigate:', '')}</a>`;
     }
     if (this.placeholders && this.placeholders[labelText]) {
       return (`${this.placeholders[labelText]} [${labelText}]`);
+    }
+    if (domain.endsWith(':all')) {
+      currentURL.searchParams.set('domain', labelText);
+      currentURL.searchParams.delete('domainkey');
+      return `<a href="${currentURL.toString()}" target="_new">${labelText}</a>`;
     }
     return escapeHTML(labelText);
   }

--- a/tools/rum/elements/list-facet.js
+++ b/tools/rum/elements/list-facet.js
@@ -161,7 +161,7 @@ export default class ListFacet extends HTMLElement {
           }
           input.id = `${facetName}=${entry.value}`;
           if (enabled) {
-            div.addEventListener('click', (evt) => {
+            input.addEventListener('click', (evt) => {
               if (evt.target !== input) input.checked = !input.checked;
               evt.stopPropagation();
               this.parentElement.parentElement.dispatchEvent(new Event('facetchange'), this);


### PR DESCRIPTION
2 changes:
-  allow to open explorer for domains (org / `:all` case)
- limit the click handler to the checkbox (super annoying that you cannot copy/paste urls)

Test: https://domain-nav--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=adobe.com%3Aall&filter=&view=month