### PR TITLE
fix(rum-explorer): unknown filter should return empty set

### DIFF
--- a/tools/rum/test/cruncher.test.js
+++ b/tools/rum/test/cruncher.test.js
@@ -671,6 +671,24 @@ describe('DataChunks', () => {
                 target: 'some_image.png',
               },
             ],
+          }, {
+            id: 'four',
+            host: 'www.anotherhost.com',
+            time: '2024-05-06T00:00:04.444Z',
+            timeSlot: '2024-05-06T00:00:00.000Z',
+            url: 'https://www.anotherhost.com/home',
+            userAgent: 'desktop',
+            weight: 100,
+            events: [
+              {
+                checkpoint: 'top',
+                target: 'hidden',
+                timeDelta: 200,
+              },
+              {
+                checkpoint: 'click',
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
While working on a conversion filter, I was surprised by the results: they had a tendency to be really good while I was expecting low results. I realised that if one of the facet in the filter is not defined on the DataChunks, it is ignored. This leads to super good results while it is just a misconfiguration of the filter. As a consumer of the cruncher, I did not know I was using the filter incorrectly, especially when you start combining multiple of them and you get already a subset of the results, it is impossible to know one is invalid and just ignored.

I think it makes more sense to return no result (and log an error) if someone is trying to filter on something which is not defined. This is much more intuitive. 

One of the existing test `DataChunk.filter(userAgent)` has the problem: it filters on `host` while `host` is not defined... The test was incomplete, if you filter by `host`, you need to have input data with different hosts to make sure you are testing the `host` filter. This would have reveal the "issue" or showcase this is a desired behaviour.