### PR TITLE
fix: only init rum if prerendered page becomes active

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -853,7 +853,12 @@ export function setup() {
  */
 export function init() {
   setup();
-  sampleRUM();
+  // Prerender-aware initialization
+  if (document.prerendering) {
+    document.addEventListener('prerenderingchange', sampleRUM, { once: true });
+  } else {
+    sampleRUM();
+  }
 }
 
 init();


### PR DESCRIPTION
To avoid collecting to many data, rum needs to be initialised only when prerendered pages become active. See https://github.com/adobe/aem-lib/issues/101.