### PR TITLE
fix: wrong date depending on timezone

### DIFF
--- a/tools/rum/elements/daterange-picker.js
+++ b/tools/rum/elements/daterange-picker.js
@@ -8,18 +8,8 @@ function debounce(func, wait) {
   };
 }
 
-// date management
-function pad(number) {
-  return number.toString().padStart(2, '0');
-}
-
 function toDateString(date) {
-  // convert date
-  const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
-
-  return `${year}-${month}-${day}`;
+  return date.toISOString().split('T')[0];
 }
 
 const STYLES = `
@@ -304,20 +294,20 @@ export default class TimeRangePicker extends HTMLElement {
 
     dropdownElement.hidden = true;
 
-    let dateFrom = new Date(from);
-    let dateTo = new Date(to);
-    if (dateFrom > dateTo) {
+    let dateFrom = from;
+    let dateTo = to;
+    if (new Date(from) > new Date(to)) {
       // swap the 2 dates
-      dateFrom = new Date(to);
-      dateTo = new Date(from);
+      dateFrom = to;
+      dateTo = from;
     }
 
-    if (from) {
-      fromElement.value = toDateString(dateFrom);
+    if (dateFrom) {
+      fromElement.value = dateFrom;
     }
 
-    if (to) {
-      toElement.value = toDateString(dateTo);
+    if (dateTo) {
+      toElement.value = dateTo;
     }
 
     this.updateTimeframe({


### PR DESCRIPTION
Depending on timezone, current time might lead to one day before or one day after the from / to selection. This leads to strange behaviours of the range picker. See recording:

https://github.com/user-attachments/assets/f97a8c19-a114-469a-98ba-a76c8825966b

Test: https://timezone-issue--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=blog.adobe.com&filter=&view=custom&startDate=2024-10-07&endDate=2024-10-08&userAgent=desktop&checkpoint=click&domainkey=incognito

Test requires to change the computer timezone.
