### PR TITLE
Smart Redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Page not found</title>
+  <script type="text/javascript">
+    window.isErrorPage = true;
+    window.errorCode = '404';
+  </script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:title" content="Page not found">
+  <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script type="module">
+    window.addEventListener('load', () => {
+      if (document.referrer) {
+        const { origin, pathname } = new URL(document.referrer);
+        if (origin === window.location.origin) {
+          const backBtn = document.createElement('a');
+          backBtn.classList.add('button', 'error-button-back');
+          backBtn.href = pathname;
+          backBtn.textContent = 'Go back';
+          backBtn.title = 'Go back';
+          const btnContainer = document.querySelector('.button-container');
+          btnContainer.append(backBtn);
+        }
+      }
+    });
+  </script>
+  <script type="module">
+    import { sampleRUM } from '/scripts/lib-franklin.js';
+    sampleRUM('404', { source: document.referrer });
+  </script>
+  <link rel="stylesheet" href="/styles/styles.css">
+  <style>
+    main.error {
+      min-height: calc(100vh - var(--nav-height));
+      display: flex;
+      align-items: center;
+    }
+
+    main.error .error-number {
+      width: 100%;
+    }
+
+    main.error .error-number text {
+      font-family: monospace;
+    }
+  </style>
+  <link rel="stylesheet" href="/styles/lazy-styles.css">
+</head>
+
+<body>
+  <header></header>
+  <main class="error">
+    <div class="section">
+      <svg viewBox="1 0 38 18" class="error-number">
+        <text x="0" y="17">404</text>
+      </svg>
+      <h2 class="error-message">Page Not Found</h2>
+      <p class="button-container">
+        <a href="/" class="button secondary error-button-home">Go home</a>
+      </p>
+    </div>
+  </main>
+  <footer></footer>
+</body>
+
+</html>

--- a/404.html
+++ b/404.html
@@ -28,6 +28,8 @@
   </script>
   <script type="module">
     import { sampleRUM } from '/scripts/lib-franklin.js';
+    import { applyRedirects } from '/scripts/redirects.js';
+    await applyRedirects();
     sampleRUM('404', { source: document.referrer });
   </script>
   <link rel="stylesheet" href="/styles/styles.css">

--- a/scripts/redirects.js
+++ b/scripts/redirects.js
@@ -1,0 +1,62 @@
+function globToRegex(glob) {
+  return new RegExp(`^${glob.replace(/\*/g, '(.*)').replace(/\?/g, '(.)').replace(/\//g, '\\/')}$`);
+}
+
+export function activateRedirects(data) {
+  return data.map((o) => Object.entries(o)
+    .reduce((acc, [k, v]) => {
+      if (k.toLowerCase() === 'from') {
+        acc.from = globToRegex(v);
+      } else if (k.toLowerCase() === 'to') {
+        acc.to = (...replacements) => {
+          replacements.shift();
+          const result = v.replace(/(\$\d+|\*)/g, (matched) => {
+            if (matched.startsWith('$')) {
+              return replacements[matched.slice(1)];
+            }
+            if (matched === '*') {
+              return replacements.shift();
+            }
+            return matched;
+          });
+          return result;
+        };
+      } else if (k.toLowerCase() === 'start') {
+        acc.start = new Date(
+          Date.UTC(1899, 11, 30, 0, 0, 0)
+          + (v - Math.floor(v)) * 86400000 + Math.floor(v) * 86400000,
+        );
+      }
+      return acc;
+    }, {}));
+}
+export async function fetchRedirects(path = '/smart-redirects.json') {
+  const response = await fetch(path);
+  const redirects = await response.json();
+  if (redirects.data) {
+    return activateRedirects(redirects.data);
+  }
+  return [];
+}
+
+export async function applyRedirects(
+  redirects = fetchRedirects(),
+  path = window.location.pathname,
+) {
+  const redirect = (await redirects)
+    .filter((r) => typeof r.start === 'undefined' || r.start.getTime() <= Date.now())
+    .find((r) => r.from.test(path));
+  if (redirect) {
+    const target = redirect.to(path, ...redirect.from.exec(path).slice(1));
+    const currentUrl = new URL(window.location.href);
+    const targetURL = new URL(target, currentUrl.origin);
+    // Copy all URL parameters from currentUrl to targetURL
+    currentUrl.searchParams.forEach((value, key) => {
+      targetURL.searchParams.set(key, value);
+    });
+
+    targetURL.searchParams.set('redirect_from', path);
+    window.location.replace(targetURL.toString());
+  }
+  return path;
+}

--- a/tests/scripts/redirects.test.js
+++ b/tests/scripts/redirects.test.js
@@ -1,0 +1,71 @@
+import { expect } from '@esm-bundle/chai';
+import { readFile } from '@web/test-runner-commands';
+import { activateRedirects, getRedirect } from '../../scripts/redirects.js';
+/* eslint-env mocha */
+
+document.body.innerHTML = await readFile({ path: './dummy.html' });
+document.head.innerHTML = await readFile({ path: './head.html' });
+
+describe.only('Redirects', () => {
+  it('loads redirects', async () => {
+    const emptyRedirects = [];
+    const redirects = await activateRedirects(emptyRedirects);
+    expect(redirects).to.deep.equal(emptyRedirects);
+  });
+
+  it('applies applies a simple redirect', async () => {
+    const exampleRedirects = [
+      {
+        from: '/foo',
+        to: '/bar',
+        start: 1,
+      },
+    ];
+    const redirects = await activateRedirects(exampleRedirects);
+    const currentURL = new URL('https://example.com/foo');
+    const redirect = await getRedirect(redirects, '/foo', currentURL);
+    expect(redirect).to.equal('https://example.com/bar?redirect_from=%2Ffoo');
+  });
+
+  it('applies applies a redirect with a parameter', async () => {
+    const exampleRedirects = [
+      {
+        from: '/foo/*',
+        to: '/bar/*',
+        start: 1,
+      },
+    ];
+    const redirects = await activateRedirects(exampleRedirects);
+    const currentURL = new URL('https://example.com/foo/baz');
+    const redirect = await getRedirect(redirects, '/foo/baz', currentURL);
+    expect(redirect).to.equal('https://example.com/bar/baz?redirect_from=%2Ffoo%2Fbaz');
+  });
+
+  it('applies applies a redirect with multiple parameters', async () => {
+    const exampleRedirects = [
+      {
+        from: '/foo/*/*',
+        to: '/bar/*/baz/*',
+        start: 1,
+      },
+    ];
+    const redirects = await activateRedirects(exampleRedirects);
+    const currentURL = new URL('https://example.com/foo/fifi/qux');
+    const redirect = await getRedirect(redirects, '/foo/fifi/qux', currentURL);
+    expect(redirect).to.equal('https://example.com/bar/fifi/baz/qux?redirect_from=%2Ffoo%2Ffifi%2Fqux');
+  });
+
+  it('applies applies a redirect with multiple parameters and changed order', async () => {
+    const exampleRedirects = [
+      {
+        from: '/foo/*/*',
+        to: '/bar/$2/baz/$1',
+        start: 1,
+      },
+    ];
+    const redirects = await activateRedirects(exampleRedirects);
+    const currentURL = new URL('https://example.com/foo/fifi/qux');
+    const redirect = await getRedirect(redirects, '/foo/fifi/qux', currentURL);
+    expect(redirect).to.equal('https://example.com/bar/qux/baz/fifi?redirect_from=%2Ffoo%2Ffifi%2Fqux');
+  });
+});


### PR DESCRIPTION
The tests requires a change to `404.html` which only applies to `main`, therefore I've written unit
tests.

Our example `smart-redirects.json` sheet has a redirect pattern rule from `/documentation/*` to `/docs/*`

- **feat(404): create error page from boilerplate**
- **feat(404): apply smart redirects, but don't send 404 checkpoint if a redirect has been found**
- **test(smartredirects): add tests for the meat of the code**
