### PR TITLE
feat(rum-oversight): do not collapse solo entry

### DIFF
--- a/tools/oversight/elements/link-facet.js
+++ b/tools/oversight/elements/link-facet.js
@@ -10,8 +10,8 @@ function urlDecode(part, rich = false) {
     : part.replace(/%3[Cc](number|hex|base64|uuid)%3[Ee]/g, '<$1>');
 }
 
-function labelURLParts(url, prefix) {
-  if (prefix && url.startsWith(prefix)) {
+function labelURLParts(url, prefix, solo = false) {
+  if (prefix && url.startsWith(prefix) && !solo) {
     return `<span class="collapse" title="${url}">${prefix}</span><span class="suffix" title="${urlDecode(url)}">${urlDecode(url.replace(prefix, ''), true)}</span>`;
   }
   const u = new URL(url);
@@ -31,7 +31,7 @@ function labelURLParts(url, prefix) {
  */
 export default class LinkFacet extends ListFacet {
   // eslint-disable-next-line class-methods-use-this
-  createLabelHTML(labelText, prefix) {
+  createLabelHTML(labelText, prefix, solo = false) {
     const thumbnailAtt = this.getAttribute('thumbnail');
     const faviconAtt = this.getAttribute('favicon');
     const isCensored = labelText.includes('...')
@@ -40,21 +40,21 @@ export default class LinkFacet extends ListFacet {
       || labelText.includes('<base64>') || labelText.includes('%3Cbase64%3E')
       || labelText.includes('<uuid>') || labelText.includes('%3Cuuid%3E');
     if (isCensored) {
-      return labelURLParts(labelText, prefix);
+      return labelURLParts(labelText, prefix, solo);
     }
     if (thumbnailAtt && labelText.startsWith('https://')) {
       const u = new URL('https://www.aem.live/tools/rum/_ogimage');
       u.searchParams.set('proxyurl', labelText);
       return `
       <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="this.classList.add('broken')">
-      <a href="${labelText}" target="_new">${labelURLParts(labelText, prefix)}</a>`;
+      <a href="${labelText}" target="_new">${labelURLParts(labelText, prefix, solo)}</a>`;
     }
     if (thumbnailAtt && (labelText.startsWith('http://') || labelText.startsWith('https://') || labelText.startsWith('android-app://'))) {
       const u = new URL('https://www.aem.live/tools/rum/_ogimage');
       u.searchParams.set('proxyurl', labelText);
       return `
       <img loading="lazy" src="${u.href}" title="${labelText}" alt="thumbnail image for ${labelText}" onerror="${faviconAtt ? `this.src='https://www.google.com/s2/favicons?domain=${labelText}&sz=256';this.classList.add('favicon');` : 'this.classList.add(\'broken\');'}">
-      <a href="${labelText}" target="_new">${labelURLParts(labelText, prefix)}</a>`;
+      <a href="${labelText}" target="_new">${labelURLParts(labelText, prefix, solo)}</a>`;
     }
     if (labelText.startsWith('https://') || labelText.startsWith('http://')) {
       return `<a href="${labelText}" target="_new">${labelText}</a>`;

--- a/tools/oversight/elements/list-facet.js
+++ b/tools/oversight/elements/list-facet.js
@@ -250,7 +250,7 @@ export default class ListFacet extends HTMLElement {
           countspan.setAttribute('sample-size', metrics.pageViews.count);
           countspan.setAttribute('total', this.dataChunks.totals.pageViews.sum);
           countspan.setAttribute('fuzzy', 'false');
-          const valuespan = this.createValueSpan(entry, prefix);
+          const valuespan = this.createValueSpan(entry, prefix, filteredKeys.length === 1);
 
           label.append(valuespan, countspan);
 
@@ -371,9 +371,9 @@ export default class ListFacet extends HTMLElement {
     }
   }
 
-  createValueSpan(entry, prefix) {
+  createValueSpan(entry, prefix, solo = false) {
     const valuespan = document.createElement('span');
-    valuespan.innerHTML = this.createLabelHTML(entry.value, prefix);
+    valuespan.innerHTML = this.createLabelHTML(entry.value, prefix, solo);
     const highlightFromParam = this.getAttribute('highlight');
     if (highlightFromParam) {
       const highlightValue = new URL(window.location).searchParams.get(highlightFromParam) || '';


### PR DESCRIPTION
When filtering out and only one url remains in the URL facet, the url is shown as `.../`. Expected: at least see the url path.

Before: https://www.aem.live/tools/oversight/explorer.html?domain=www.adobe.com&filter=%2Fproducts%2Fcatalog.html&view=month&=performance&domainkey=incognito&conversion.checkpoint=click
After: https://solo-url--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=www.adobe.com&filter=%2Fproducts%2Fcatalog.html&view=month&=performance&domainkey=incognito&conversion.checkpoint=click