### PR TITLE
feat(rum): show N/A if no visit data is provided (org case)

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -104,48 +104,54 @@ export function updateKeyMetrics() {
     document.querySelector('#pageviews p').appendChild(pageViewsExtra);
   }
 
-  document.querySelector('#visits p number-format').textContent = dataChunks.totals.visits.sum;
-  document.querySelector('#visits p number-format').setAttribute('sample-size', dataChunks.totals.visits.count);
-  document.querySelector('#visits p number-format').setAttribute('total', dataChunks.totals.pageViews.sum);
   if (dataChunks.totals.visits.sum > 0) {
+    document.querySelector('#visits p number-format').textContent = dataChunks.totals.visits.sum;
+    document.querySelector('#visits p number-format').setAttribute('sample-size', dataChunks.totals.visits.count);
+    document.querySelector('#visits p number-format').setAttribute('total', dataChunks.totals.pageViews.sum);
     const visitsExtra = document.querySelector('#visits p number-format.extra') || document.createElement('number-format');
     visitsExtra.textContent = (100 * dataChunks.totals.bounces.sum) / dataChunks.totals.visits.sum;
     visitsExtra.setAttribute('precision', 1);
     visitsExtra.setAttribute('total', 100);
     visitsExtra.className = 'extra';
     document.querySelector('#visits p').appendChild(visitsExtra);
-  }
-
-  if (isDefaultConversion) {
-    document.querySelector('#conversions p number-format').textContent = dataChunks.totals.engagement.sum;
-    document.querySelector('#conversions p number-format').setAttribute('sample-size', dataChunks.totals.engagement.count);
   } else {
-    document.querySelector('#conversions p number-format').textContent = dataChunks.totals.conversions.sum;
-    document.querySelector('#conversions p number-format').setAttribute('sample-size', dataChunks.totals.conversions.count);
+    document.querySelector('#visits p number-format').textContent = 'N/A';
   }
 
-  document.querySelector('#conversions p number-format').setAttribute('total', dataChunks.totals.visits.sum);
-  const conversionsExtra = document.querySelector('#conversions p number-format.extra') || document.createElement('number-format');
-  if (dataChunks.totals.pageViews.sum > 0 && isDefaultConversion) {
-    conversionsExtra.textContent = computeConversionRate(
-      dataChunks.totals.engagement.sum,
-      dataChunks.totals.pageViews.sum,
-    );
-    // this is a bit of fake precision, but it's good enough for now
-    conversionsExtra.setAttribute('precision', 2);
-    conversionsExtra.setAttribute('total', 100);
-    conversionsExtra.className = 'extra';
-    document.querySelector('#conversions p').appendChild(conversionsExtra);
-  } else if (dataChunks.totals.visits.sum > 0 && !isDefaultConversion) {
-    conversionsExtra.textContent = computeConversionRate(
-      dataChunks.totals.conversions.sum,
-      dataChunks.totals.visits.sum,
-    );
-    // this is a bit of fake precision, but it's good enough for now
-    conversionsExtra.setAttribute('precision', 2);
-    conversionsExtra.setAttribute('total', 100);
-    conversionsExtra.className = 'extra';
-    document.querySelector('#conversions p').appendChild(conversionsExtra);
+  if (dataChunks.totals.visits.sum > 0) {
+    if (isDefaultConversion) {
+      document.querySelector('#conversions p number-format').textContent = dataChunks.totals.engagement.sum;
+      document.querySelector('#conversions p number-format').setAttribute('sample-size', dataChunks.totals.engagement.count);
+    } else {
+      document.querySelector('#conversions p number-format').textContent = dataChunks.totals.conversions.sum;
+      document.querySelector('#conversions p number-format').setAttribute('sample-size', dataChunks.totals.conversions.count);
+    }
+
+    document.querySelector('#conversions p number-format').setAttribute('total', dataChunks.totals.visits.sum);
+    const conversionsExtra = document.querySelector('#conversions p number-format.extra') || document.createElement('number-format');
+    if (dataChunks.totals.pageViews.sum > 0 && isDefaultConversion) {
+      conversionsExtra.textContent = computeConversionRate(
+        dataChunks.totals.engagement.sum,
+        dataChunks.totals.pageViews.sum,
+      );
+      // this is a bit of fake precision, but it's good enough for now
+      conversionsExtra.setAttribute('precision', 2);
+      conversionsExtra.setAttribute('total', 100);
+      conversionsExtra.className = 'extra';
+      document.querySelector('#conversions p').appendChild(conversionsExtra);
+    } else if (dataChunks.totals.visits.sum > 0 && !isDefaultConversion) {
+      conversionsExtra.textContent = computeConversionRate(
+        dataChunks.totals.conversions.sum,
+        dataChunks.totals.visits.sum,
+      );
+      // this is a bit of fake precision, but it's good enough for now
+      conversionsExtra.setAttribute('precision', 2);
+      conversionsExtra.setAttribute('total', 100);
+      conversionsExtra.className = 'extra';
+      document.querySelector('#conversions p').appendChild(conversionsExtra);
+    }
+  } else {
+    document.querySelector('#conversions p number-format').textContent = 'N/A';
   }
 
   const lcpElem = document.querySelector('#lcp p number-format');

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -66,21 +66,25 @@ export function updateKeyMetrics(keyMetrics) {
     document.querySelector('#pageviews p').appendChild(pageViewsExtra);
   }
 
-  document.querySelector('#visits p').textContent = toHumanReadable(keyMetrics.visits);
   if (keyMetrics.visits > 0) {
+    document.querySelector('#visits p').textContent = toHumanReadable(keyMetrics.visits);
     const visitsExtra = document.createElement('span');
     visitsExtra.textContent = toHumanReadable((100 * keyMetrics.bounces) / keyMetrics.visits);
     visitsExtra.className = 'extra';
     document.querySelector('#visits p').appendChild(visitsExtra);
+  } else {
+    document.querySelector('#visits p').textContent = 'N/A';
   }
 
-  document.querySelector('#conversions p').textContent = toHumanReadable(keyMetrics.conversions);
   if (keyMetrics.visits > 0) {
+    document.querySelector('#conversions p').textContent = toHumanReadable(keyMetrics.conversions);
     const conversionsExtra = document.createElement('span');
     const conversionRate = computeConversionRate(keyMetrics.conversions, keyMetrics.pageViews);
     conversionsExtra.textContent = toHumanReadable(conversionRate);
     conversionsExtra.className = 'extra';
     document.querySelector('#conversions p').appendChild(conversionsExtra);
+  } else {
+    document.querySelector('#conversions p').textContent = 'N/A';
   }
 
   const lcpElem = document.querySelector('#lcp p');


### PR DESCRIPTION
In the case of an org, the bundles contain only a subset of the checkpoints, not including `enter`, i.e. `visit` is always 0. This is not intuitive. While we can work on a better UX, a quick fix is to show `N/A`.