### PR TITLE
feat(rum): allow to see source of missingresource

### DIFF
--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -314,6 +314,11 @@
             <list-facet facet="loadresource.source">
               <legend>Resource Loaded</legend>
             </list-facet>
+
+            <list-facet facet="missingresource.source">
+              <legend>Missing Resource</legend>
+            </list-facet>
+
             <literal-facet facet="cwv-lcp.source">
               <legend>LCP Element (DOM)</legend>
             </literal-facet>

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -255,6 +255,10 @@
               <legend>Resource Loaded</legend>
             </list-facet>
 
+            <list-facet facet="missingresource.source">
+              <legend>Missing Resource</legend>
+            </list-facet>
+
             <literal-facet facet="cwv-lcp.source">
               <legend>LCP Element (DOM)</legend>
             </literal-facet>


### PR DESCRIPTION
Allow to see the `source` of the `missingresource` checkpoint