### PR TITLE
feat: include end of the last day of the selected period

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -317,7 +317,7 @@ async function loadData(config) {
   const endDate = params.get('endDate') ? `${params.get('endDate')}` : null;
 
   if (startDate && endDate) {
-    dataChunks.load(await loader.fetchPeriod(startDate, endDate));
+    dataChunks.load(await loader.fetchPeriod(`${startDate} 00:00:00`, `${endDate} 23:59:59`));
   } else if (scope === 'week') {
     dataChunks.load(await loader.fetchLastWeek(endDate));
   } else if (scope === 'month') {

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -273,7 +273,7 @@ async function loadData(config) {
   const endDate = params.get('endDate') ? `${params.get('endDate')}` : null;
 
   if (startDate && endDate) {
-    dataChunks.load(await loader.fetchPeriod(startDate, endDate));
+    dataChunks.load(await loader.fetchPeriod(`${startDate} 00:00:00`, `${endDate} 23:59:59`));
   } else if (scope === 'week') {
     dataChunks.load(await loader.fetchLastWeek(endDate));
   } else if (scope === 'month') {


### PR DESCRIPTION
When selecting a date range, the last day does not contain data.

Text: https://end-of-date--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=www.maidenform.com&filter=&view=custom&startDate=2024-11-12&endDate=2024-11-18&domainkey=