### PR TITLE
fix: Math.max crashes if too many deltas

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -71,7 +71,8 @@ dataChunks.addSeries('timeOnPage', (bundle) => {
   if (deltas.length === 0) {
     return undefined;
   }
-  return Math.max(...deltas) / 1000;
+  // get max delta and divide by 1000 to get seconds
+  return (deltas.reduce((a, b) => Math.max(a, b), -Infinity)) / 1000;
 });
 
 dataChunks.addSeries('contentEngagement', (bundle) => {


### PR DESCRIPTION
`Math.max(...array)` cannot be used if `array` has a lot of elements

Last week, adobe.com had a weird session with 163665 click events! This makes the oversight/explorer crash.

Before: https://www.aem.live/tools/oversight/explorer.html?domain=www.adobe.com&filter=&view=week&=performance
After: https://max-crash--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=www.adobe.com&filter=&view=week&=performance
