### PR TITLE
chore: add publication-date to helix-query.yaml

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -24,6 +24,10 @@ indices:
         select: head > meta[name="robots"]
         value: |
           attribute(el, 'content')
+      publicationDate:
+        select: head > meta[name="publication-date"]
+        value: |
+          attribute(el, 'content')
   docpages:
     target: /docpages-index
     include:


### PR DESCRIPTION
## Description
This PR adds publication-date to helix-query.yaml to index this field for blog posts

## Related Issue
#731 

## Motivation and Context
This will be helpful for filtering blogs on blog listing page

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


https://main--helix-website--adobe.aem.page/blog/aem-live-at-dev-live
vs
https://issue-731--helix-website--adobe.aem.page/blog/aem-live-at-dev-live