### PR TITLE
Slack notification should be sent when docs are published

### DIFF
--- a/.github/workflows/log-publish.yml
+++ b/.github/workflows/log-publish.yml
@@ -30,6 +30,8 @@ jobs:
             {
               "text": "Just published: `${{ github.event.client_payload.path }}`"
             }
+          webhook-type: webhook-trigger
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
       - name: Notify Slack (Markdown)
         if: ${{ endsWith(github.event.client_payload.path, '.md') }}
         uses: slackapi/slack-github-action@v2.0.0
@@ -41,3 +43,5 @@ jobs:
             {
               "text": "Just published: https://www.aem.live${{ steps.format.outputs.replaced }}"
             }
+          webhook-type: webhook-trigger
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds webhook-type for slack-github-action which currently fails sending notification on slack channel when docs are published

## Related Issue
#733 

## Motivation and Context
This was working before a dependency update happened 2 weeks back, this PR will fix the issue.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
