### PR TITLE
fix: simplify Y labelling

### DIFF
--- a/tools/oversight/charts/skyline.js
+++ b/tools/oversight/charts/skyline.js
@@ -291,14 +291,14 @@ export default class SkylineChart extends AbstractChart {
             ticks: {
               autoSkip: false,
               maxTicksLimit: 16,
-              callback: (value, index) => {
+              callback: (value, index, arr) => {
                 if (value === 0) return '';
                 if (value > 0) {
                   return toHumanReadable(value);
                 }
                 if (index === 0) return 'INP';
                 if (index === 1) return 'CLS';
-                if (index === 2) return 'LCP';
+                if (index === 3 || (index === 2 && arr[index + 1].value === 0)) return 'LCP';
                 return '';
               },
             },

--- a/tools/oversight/charts/skyline.js
+++ b/tools/oversight/charts/skyline.js
@@ -294,19 +294,11 @@ export default class SkylineChart extends AbstractChart {
               callback: (value, index) => {
                 if (value === 0) return '';
                 if (value > 0) {
-                  this.clsAlreadyLabeled = false;
-                  this.lcpAlreadyLabeled = false;
                   return toHumanReadable(value);
                 }
                 if (index === 0) return 'INP';
-                if (value / this.min < 0.4 && !this.lcpAlreadyLabeled) {
-                  this.lcpAlreadyLabeled = true;
-                  return 'LCP';
-                }
-                if (value / this.min < 0.7 && !this.clsAlreadyLabeled) {
-                  this.clsAlreadyLabeled = true;
-                  return 'CLS';
-                }
+                if (index === 1) return 'CLS';
+                if (index === 2) return 'LCP';
                 return '';
               },
             },

--- a/tools/rum/charts/skyline.js
+++ b/tools/rum/charts/skyline.js
@@ -304,19 +304,11 @@ export default class SkylineChart extends AbstractChart {
               callback: (value, index) => {
                 if (value === 0) return '';
                 if (value > 0) {
-                  this.clsAlreadyLabeled = false;
-                  this.lcpAlreadyLabeled = false;
                   return toHumanReadable(value);
                 }
                 if (index === 0) return 'INP';
-                if (value / this.min < 0.4 && !this.lcpAlreadyLabeled) {
-                  this.lcpAlreadyLabeled = true;
-                  return 'LCP';
-                }
-                if (value / this.min < 0.7 && !this.clsAlreadyLabeled) {
-                  this.clsAlreadyLabeled = true;
-                  return 'CLS';
-                }
+                if (index === 1) return 'CLS';
+                if (index === 2) return 'LCP';
                 return '';
               },
             },

--- a/tools/rum/charts/skyline.js
+++ b/tools/rum/charts/skyline.js
@@ -301,14 +301,14 @@ export default class SkylineChart extends AbstractChart {
             ticks: {
               autoSkip: false,
               maxTicksLimit: 16,
-              callback: (value, index) => {
+              callback: (value, index, arr) => {
                 if (value === 0) return '';
                 if (value > 0) {
                   return toHumanReadable(value);
                 }
                 if (index === 0) return 'INP';
                 if (index === 1) return 'CLS';
-                if (index === 2) return 'LCP';
+                if (index === 3 || (index === 2 && arr[index + 1].value === 0)) return 'LCP';
                 return '';
               },
             },


### PR DESCRIPTION
Open https://www.aem.live/tools/rum/explorer.html?domain=www.ups.com&view=month&domainkey=incognito
Check the Y axis labels of the chart: CLS is missing. It is not the case for all charts (works for https://www.aem.live/tools/rum/explorer.html?domain=blog.adobe.com&view=month&domainkey=incognito

Test:
- https://missing-label--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=www.ups.com&view=month&domainkey=incognito
- https://missing-label--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=blog.adobe.com&view=month&domainkey=incognito

Just simplified the logic...