### PR TITLE
bug: deselecting a checkpoint breaks the dashboard in certain scenarios

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -366,6 +366,8 @@ export function updateState() {
     });
   });
 
+  // remove all source and target filters if their specific checkpoint
+  // is not in the checkpoint filter
   url.searchParams.entries().filter(([key]) => key.match(/\.(source|target)$/))
     .forEach(([key]) => {
       const [cp] = key.split('.');

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -36,7 +36,7 @@ const API_ENDPOINT = BUNDLER_ENDPOINT;
 const elems = {};
 
 const dataChunks = new DataChunks();
-
+window.dataChunks = dataChunks;
 const loader = new DataLoader();
 loader.apiEndpoint = API_ENDPOINT;
 
@@ -366,6 +366,13 @@ export function updateState() {
     });
   });
 
+  url.searchParams.entries().filter(([key]) => key.match(/\.(source|target)$/))
+    .forEach(([key]) => {
+      const [cp] = key.split('.');
+      if (!url.searchParams.getAll('checkpoint').includes(cp)) {
+        url.searchParams.delete(key);
+      }
+    });
   // iterate over all existing URL parameters and keep those that are known facets
   // and end with ~, so that we can keep the state of the facets
   searchParams.forEach((value, key) => {

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -36,7 +36,7 @@ const API_ENDPOINT = BUNDLER_ENDPOINT;
 const elems = {};
 
 const dataChunks = new DataChunks();
-window.dataChunks = dataChunks;
+
 const loader = new DataLoader();
 loader.apiEndpoint = API_ENDPOINT;
 

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -305,6 +305,16 @@ export function updateState() {
   });
   url.searchParams.set('domainkey', searchParams.get('domainkey') || 'incognito');
 
+  // remove all source and target filters if their specific checkpoint
+  // is not in the checkpoint filter
+  url.searchParams.entries().filter(([key]) => key.match(/\.(source|target)$/))
+    .forEach(([key]) => {
+      const [cp] = key.split('.');
+      if (!url.searchParams.getAll('checkpoint').includes(cp)) {
+        url.searchParams.delete(key);
+      }
+    });
+
   window.history.replaceState({}, '', url);
   document.dispatchEvent(new CustomEvent('urlstatechange', { detail: url }));
 }


### PR DESCRIPTION
fixes #747 

Try the same steps with this URL (replace `incognito` with the correct domain key)

https://deselect-checkpoint--helix-website--vdua.aem.live/tools/oversight/explorer.html?domain=business.adobe.com&filter=&view=month&=performance&checkpoint=click&click.source=button.con-button&domainkey=incognito&conversion.checkpoint=click

## Description

We remove the source/target filters from the state if the checkpoint is not present in the filter.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
