### PR TITLE
fix: broken top margins

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1931,9 +1931,7 @@ body.guides-template .guides-back-btn span.icon {
     margin-bottom: var(--spacing-l);
   }
 
-  body.guides-template,
-  main.without-full-width-hero,
-  .default-content-wrapper,
+  body.guides-template main.without-full-width-hero .default-content-wrapper,
   body.skills-template,
   h1 {
     margin-top: var(--spacing-ml);


### PR DESCRIPTION
There is a margin issue at the top of most pages and the breadcrumb that was introduced by accident...

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/08c4035b-d62b-442b-9e7d-1e3e71ac2e64" />
<img width="644" alt="image" src="https://github.com/user-attachments/assets/39cfd12a-b432-4bbc-9a8a-abf43a7f186a" />

see: https://github.com/adobe/helix-website/commit/5e0e854282c16d49d90eb05307df1bfa0a5e9524#diff-37f6471b306924bbb531d040e7ab55df5f83511246a411d22947462323516afaR1932-R1936

https://main--helix-website--adobe.aem.live/
https://main--helix-website--adobe.aem.live/docs/

vs.

https://fix-margin--helix-website--adobe.aem.live/
https://fix-margin--helix-website--adobe.aem.live/docs/