### PR TITLE
feat: adding viewmedia and viewblock scroll depth

### DIFF
--- a/tools/oversight/elements/list-facet.js
+++ b/tools/oversight/elements/list-facet.js
@@ -300,6 +300,16 @@ export default class ListFacet extends HTMLElement {
           engagementLI.classList.add('conversion');
           ul.append(engagementLI);
 
+          const viewblockDepthLI = this.createBusinessMetricChiclet(entry, 'viewblock', null, 25, 60, 80);
+          viewblockDepthLI.title = 'Viewblock Depth';
+          viewblockDepthLI.classList.add('conversion');
+          ul.append(viewblockDepthLI);
+
+          const viewMediaDepthLI = this.createBusinessMetricChiclet(entry, 'viewmedia', null, 25, 60, 80);
+          viewMediaDepthLI.title = 'View Media Depth';
+          viewMediaDepthLI.classList.add('conversion');
+          ul.append(viewMediaDepthLI);
+
           const conversionRateLI = this.createBusinessMetricChiclet(entry, 'conversions', 'visits', 5, 10, 20);
           conversionRateLI.title = 'Conversion Rate';
           conversionRateLI.classList.add('conversion');
@@ -468,6 +478,10 @@ export default class ListFacet extends HTMLElement {
           total: this.dataChunks.totals[baseline].count,
           conversions: this.dataChunks.totals[rate].count,
         });
+      } else if (rate === 'viewblock' || rate === 'viewmedia') {
+        const value = (entry.metrics[rate].percentile(50) / entry.metrics[rate].max) * 100;
+        nf.textContent = value;
+        meter.value = Number.isFinite(value) ? value : 0;
       } else {
         // we show the median and use a t-test between all values
         const value = entry.metrics[rate].percentile(50);

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -540,7 +540,6 @@ facet-sidebar:has(input[name="focus"][value="conversion"]) aside ul.cwv li.conve
 
 facet-sidebar:has(input[name="focus"][value="conversion"]:checked) aside ul.cwv li.conversion {
   display: flex;
-  grid-column: span 3;
 }
 
 ul.cwv meter {
@@ -657,6 +656,14 @@ fieldset div:first-of-type li:nth-of-type(7)::before {
 }
 
 fieldset div:first-of-type li:nth-of-type(8)::before {
+  content: 'Viewblock';
+}
+
+fieldset div:first-of-type li:nth-of-type(9)::before {
+  content: 'Viewmedia';
+}
+
+fieldset div:first-of-type li:nth-of-type(10)::before {
   content: 'Conversion';
 }
 

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -42,6 +42,13 @@ loader.apiEndpoint = API_ENDPOINT;
 
 const herochart = new window.slicer.Chart(dataChunks, elems);
 
+const eventCountFn = (type) => (bundle) => {
+  const eventCount = bundle.events.filter(
+    (e) => e.checkpoint === type,
+  ).length;
+  return eventCount;
+};
+
 window.addEventListener('pageshow', () => !elems.canvas && herochart.render());
 
 // set up metrics for dataChunks
@@ -59,6 +66,10 @@ dataChunks.addSeries('conversions', (bundle) => (dataChunks.hasConversion(bundle
   : 0));
 
 dataChunks.addSeries('organic', organic);
+
+dataChunks.addSeries('viewblock', eventCountFn('viewblock'));
+dataChunks.addSeries('viewmedia', eventCountFn('viewmedia'));
+
 /*
  * timeOnPage is the time it took to load the page,
  * i.e. the difference between the first and last event


### PR DESCRIPTION
- Adding `viewmedia`, `viewblock` series
- Adding `Viewmedia Depth` and `Viewblock Depth` to Conversion chicklet in oversight (please see the screenshot)
- Depth is calculated as `(median / max) * 100` of the facet data, which gives the median percent of blocks/media viewed, which is kind of representative of scroll depth. For example, if the median of viewblock is 3 and max block is 10, then 50% of the users have seen 30% of scroll depth

<img width="821" alt="image" src="https://github.com/user-attachments/assets/0668ae7c-4d57-476c-bc78-3dfc28d15633" />
