### PR TITLE
Multiple author support in author-box

### DIFF
--- a/blocks/author-box/author-box.css
+++ b/blocks/author-box/author-box.css
@@ -17,11 +17,18 @@ main .author-box {
 
 main .author-box-info {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   align-items: center;
   margin-top: 40px;
   margin-bottom: 40px;
   padding: 0 2rem;
+}
+
+main .author-box-info .author-container {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 20px; /* Add space between author rows */
 }
 
 main .author-box-info .sharing-details {
@@ -61,12 +68,51 @@ main .author-box-info .sharing-details svg {
 main .author-box-info .blog-author-blurb {
   font-style: italic;
   color: grey;
-  padding-left: 15px;
+}
+
+main .author-box-info .single-author .blog-author-blurb {
   display: none;
 }
 
 main .author-box-info .publication-date-invalid {
   display: none;
+}
+
+main .author-containers .blog-author-info {
+  position: relative;
+  display: inline-block;
+}
+
+main .author-containers .blog-author-info .sharing-details {
+  position: absolute;
+  bottom: 0;
+  right: 15px;
+  background-color: white;
+  border-radius: 20px;
+}
+
+main .author-containers .blog-author-info .sharing-details svg {
+  width: 20px;
+  height: 20px;
+}
+
+main .author-box-info .blog-publication-date {
+  text-align: center;
+  display: block;
+  width: 100%;
+  padding: 1rem;
+}
+
+main .author-box-info .single-author .blog-publication-date {
+  text-align: left;
+  display: block;
+  width: 100%;
+  padding: 0;
+  font-size: 16px;
+}
+
+main .author-box-info .blog-author-details .blog-author-name {
+  font-weight: bold;
 }
 
 @media (width >= 600px) {
@@ -78,45 +124,135 @@ main .author-box-info .publication-date-invalid {
   }
 
   main .author-box .author-box-info {
-    max-width: 900px;
+    max-width: 650px;
     margin-left: auto;
     margin-right: auto;
   }
 
   main .author-box-info .blog-author-blurb {
-    max-width: 290px;
-    margin-left: 10px;
-    border-left: 1px solid grey;
-    display: block;
+    max-width: 280px;
     font-size: 15px;
+  }
+
+  main .author-box-info .single-author .blog-author-blurb {
+    display: block;
+    padding-left: 30px;
+    border-left: 1px solid grey;
   }
 
   main .author-box-info .blog-author-details {
     font-size: 16px;
+    padding-right: 10px;
   }
+
+  main .author-box-info .blog-publication-date {
+    text-align: left;
+  }
+
+  main .author-box-info .author-containers {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    width: 100%;
+    padding: 0 1rem;
+  }
+
+  main .author-box-info .multiple-authors .blog-author-details {
+    border-right: none;
+  }
+
+  /* main .author-box-info .single-author .blog-author-details {
+    padding-right: 30px;
+  } */
 }
 
 @media (width >= 768px) {
+  main .author-box .author-box-info {
+    max-width: 650px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0;
+  }
+
   main .author-box-info .blog-author-blurb {
     max-width: 380px;
     margin-left: 20px;
     font-size: 18px;
   }
 
-  main .author-box-info .blog-author-details {
+  main .author-box-info .multiple-authors .blog-author-details {
     font-size: 18px;
+    padding-right: 10px;
+  }
+
+  main .author-box-info .author-containers .blog-author-blurb {
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  main .author-box-info .single-author .blog-author-blurb {
+    padding-left: 30px;
+  }
+
+  main .author-containers .blog-author-info .sharing-details {
+    right: 10px;
   }
 }
 
 @media (width >= 900px) {
-  main .author-box-info .blog-author-blurb {
-    max-width: 450px;
-    font-size: 20px;
-    margin-left: 30px;
+  main .author-box .author-box-info {
+    max-width: 740px;
     padding-left: 30px;
+    padding-right: 30px;
+  }
+
+  main .author-box-info .single-author .blog-author-blurb {
+    max-width: 400px;
+    font-size: 18px;
+    margin-left: 10px;
+    padding-left: 30px;
+  }
+
+  main .author-box-info .multiple-authors .blog-author-blurb {
+    max-width: 500px;
+    font-size: 20px;
+    margin-left: 0;
+    padding-left: 0;
   }
 
   main .author-box-info .blog-author-details {
     font-size: 20px;
+  }
+
+  main .author-box-info .author-container .blog-author-details {
+    border-right: none;
+  }
+}
+
+@media (width >= 1200px) {
+  main .author-box .author-box-info {
+    max-width: 800px;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  main .author-box-info .multiple-authors .blog-author-details {
+    padding-right: 30px;
+  }
+
+  main .author-containers .blog-author-info .sharing-details {
+    right: 15px;
+  }
+
+  main .author-box-info .single-author .blog-author-blurb {
+    max-width: 500px;
+  }
+}
+
+@media (width >= 1400px) {
+  main .author-box .author-box-info {
+    max-width: 880px;
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -459,15 +459,20 @@ function decorateBreadcrumb(main) {
 
   const list = createTag('ul');
   const home = createTag('li', {}, '<a href="/home" class="breadcrumb-link-underline-effect">Home</a>');
-  const docs = createTag('li', {}, '<a href="/docs/" class="breadcrumb-link-underline-effect">Documentation</a>');
-
   list.append(home);
-  list.append(docs);
+
+  const template = getMetadata('template');
+
+  if (template === 'blog') {
+    const blog = createTag('li', {}, '<a href="/blog" class="breadcrumb-link-underline-effect">Blog</a>');
+    list.append(blog);
+  } else {
+    const docs = createTag('li', {}, '<a href="/docs/" class="breadcrumb-link-underline-effect">Documentation</a>');
+    list.append(docs);
+  }
 
   const category = getMetadata('category');
   const title = getMetadata('og:title');
-  const template = getMetadata('template');
-
   if (category) {
     const section = createTag(
       'li',
@@ -477,7 +482,7 @@ function decorateBreadcrumb(main) {
     list.append(section);
   }
 
-  if (template) {
+  if (template && template !== 'blog') {
     const section = createTag(
       'li',
       {},
@@ -555,15 +560,18 @@ function decorateSVGs(main) {
 
 function buildAuthorBox(main) {
   const div = document.createElement('div');
-  const author = getMetadata('author');
+  const authors = getMetadata('author').split(',').map((author) => author.trim());
   const publicationDate = getMetadata('publication-date');
-  const authorImage = getMetadata('author-image');
+  const authorImages = authors.map((_, i) => getMetadata(`author${i + 1}-image`));
+  const authorBlurbs = authors.map((_, i) => getMetadata(`author${i + 1}-blurb`));
 
-  const authorBoxBlockEl = buildBlock('author-box', [
-    [`<img src="${authorImage}" alt="${author}" title="${author}">`,
-      `<p>${author}</p>
-      <p>${publicationDate}</p>`],
-  ]);
+  const authorBoxBlockEl = buildBlock('author-box', authors.map((author, i) => [
+    `<img src="${authorImages[i]}" alt="${author}" title="${author}">`,
+    `<p>${author}</p>
+    <p>${publicationDate}</p>
+    <p>${authorBlurbs[i]}</p>`,
+  ]));
+
   div.append(authorBoxBlockEl);
   main.append(div);
 }


### PR DESCRIPTION
## Description
This PR covers:

- Adding support for multiple authors in author-box block for aem.live/blog
- Updating navigation to blog section from breadcrumb
- It also slightly updates the styling for author-box for single author.

## Related Issue
#773 

## Motivation and Context
Currently author-box supports only one author, this PR enhances the block to support multiple authors. This will be useful for future blogs too where more than one author contributes to the blog

## How Has This Been Tested?
Multiple authors:
https://main--helix-website--adobe.aem.page/drafts/asthabharga/blog
vs
https://issue-773--helix-website--adobe.aem.page/drafts/asthabharga/blog

Single author:
https://main--helix-website--adobe.aem.page/blog/aem-live-at-dev-live
vs
https://issue-773--helix-website--adobe.aem.page/blog/aem-live-at-dev-live

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
