### PR TITLE
Added block option styles to Cards block

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -61,16 +61,16 @@
   border-right-color: #6a6969; 
 }
 
-.cards.alternate a:hover:any-link::after {
-  transform: none;
-}
-
 .cards a:hover:any-link::after {
   color: var(--spectrum-blue);
   transform: translateX(3px);
 }
 
-.cards a:hover:any-link::after {  
+.cards.alternate a:hover:any-link::after {
+  transform: none;
+}
+
+.cards.alternate a:hover:any-link::after {  
   color: var(--spectrum-blue);
   border-left-width: 80px; 
   border-right-width: 80px;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -43,9 +43,9 @@
   right: -1rem;
   width: 0;
   height: 0;
-  border-left: 40px solid transparent; 
-  border-right: 40px solid transparent; 
-  border-bottom: 40px solid transparent;
+  border-left: 20px solid transparent; 
+  border-right: 20px solid transparent; 
+  border-bottom: 20px solid transparent;
   transition: border-width 0.1s ease-in-out;
 }
 
@@ -64,15 +64,6 @@
 .cards a:hover:any-link::after {
   color: var(--spectrum-blue);
   transform: translateX(3px);
-}
-
-.cards.alternate a:hover:any-link::after {  
-  color: var(--spectrum-blue);
-  border-left-width: 80px; 
-  border-right-width: 80px;
-  border-bottom-width: 80px;
-  transform: none;
-}
 
 .cards .cards-card {
   width: 100%;
@@ -104,6 +95,14 @@
 .cards .cards-card.enter:hover {
   transform: scale(calc(100% + 1rem), calc(100% + 1rem)) translate(0, 0);
 }
+
+.cards.alternate .cards-card.enter:hover a:any-link::after{
+  border-left-width: 35px; 
+  border-right-width: 35px;
+  border-bottom-width: 35px;
+  transform: none;
+}
+
 
 /* Fade in the pseudo-element with the bigger shadow */
 .cards .cards-card:hover::after {

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -66,15 +66,12 @@
   transform: translateX(3px);
 }
 
-.cards.alternate a:hover:any-link::after {
-  transform: none;
-}
-
 .cards.alternate a:hover:any-link::after {  
   color: var(--spectrum-blue);
   border-left-width: 80px; 
   border-right-width: 80px;
   border-bottom-width: 80px;
+  transform: none;
 }
 
 .cards .cards-card {

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -64,6 +64,7 @@
 .cards a:hover:any-link::after {
   color: var(--spectrum-blue);
   transform: translateX(3px);
+}
 
 .cards .cards-card {
   width: 100%;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -36,9 +36,45 @@
   transition: all 0.3s ease-in-out;
 }
 
+.cards.alternate a:any-link::after {
+  content: "";
+  position: absolute;
+  top: -2rem;
+  right: -1rem;
+  width: 0;
+  height: 0;
+  border-left: 40px solid transparent; 
+  border-right: 40px solid transparent; 
+  border-bottom: 40px solid transparent;
+  transition: border-width 0.1s ease-in-out;
+}
+
+.cards.earlyaccess a:any-link::after {
+  border-right-color: #e6118a; 
+}
+
+.cards.deprecated a:any-link::after {
+  border-right-color: #d31510; 
+}
+
+.cards.removed a:any-link::after {
+  border-right-color: #6a6969; 
+}
+
+.cards.alternate a:hover:any-link::after {
+  transform: none;
+}
+
 .cards a:hover:any-link::after {
   color: var(--spectrum-blue);
   transform: translateX(3px);
+}
+
+.cards a:hover:any-link::after {  
+  color: var(--spectrum-blue);
+  border-left-width: 80px; 
+  border-right-width: 80px;
+  border-bottom-width: 80px;
 }
 
 .cards .cards-card {

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -27,7 +27,7 @@ export default function decorate(block) {
       // highlight styling
       const links = details.querySelectorAll('a');
       links.forEach((link) => {
-        link.classList.add('link-highlight-colorful-effect-hover-wrapper');
+        link.className = 'link-highlight-colorful-effect-hover-wrapper';
         link.innerHTML = `<span class="link-highlight-colorful-effect-2">${link.textContent}</span>`;
       });
       cell.append(details);


### PR DESCRIPTION
- Adds baseline alternate definition for upper-corner triangle
- Adds with 3 color options (red for deprecated, pink-ish for early access, grey for removed). 
- Fixes a minor issue with the Cards JS where adding card block options applies baseline button styles to contained links in addition to 'link-highlight-colorful-effect-hover-wrapper'.  This is 

https://github.com/adobe/helix-website/issues/782

Before: https://main--helix-website--adobe.aem.page/drafts/brwarner/lifecycle
After: https://coloredcardcorners--helix-website--adobe.aem.page/drafts/brwarner/lifecycle