### PR TITLE
FAQ: add optional categories and filters

### DIFF
--- a/blocks/faq/faq.css
+++ b/blocks/faq/faq.css
@@ -51,7 +51,6 @@ body.guides-template main .faq dt a.anchor-link:any-link::before {
 main .faq .filter-controls {
   display: flex;
   font-size: var(--type-body-xs-size);
-  font-weight: 700;
   background-color: var(--bg-color-lightgrey);
   padding: var(--spacing-xxs) var(--spacing-s);
   border: solid 1px var(--bg-color-grey-2);

--- a/blocks/faq/faq.css
+++ b/blocks/faq/faq.css
@@ -22,16 +22,21 @@ main .faq .category {
 }
 
 main .faq .category.style-1 {
-  background-color: var(--brand-color-purple);
+  background-color: var(--brand-color-dark-purple);
   color: var(--color-white);
 }
 
 main .faq .category.style-2 {
-  background-color: var(--brand-color-pink);
-  color: var(--color-white);}
+  background-color: var(--color-accent-pink-content);
+  color: var(--color-white);
+}
 
 main .faq .category.style-3 {
-  background-color: var(--brand-color-green-yellow);
+  background-color: var(--color-accent-pink-bg);
+}
+
+main .faq .category.style-4 {
+  background-color: var(--color-accent-lightgreen-bg);
 }
 
 main .faq dd {
@@ -46,10 +51,12 @@ body.guides-template main .faq dt a.anchor-link:any-link::before {
 main .faq .filter-controls {
   display: flex;
   font-size: var(--type-body-xs-size);
+  font-weight: 700;
 }
 
 main .faq .filter-control label {
   cursor: pointer;
+  user-select: none;
 }
 
 main .faq .filter-control input[type="checkbox"] {

--- a/blocks/faq/faq.css
+++ b/blocks/faq/faq.css
@@ -52,7 +52,7 @@ main .faq .filter-controls {
   display: flex;
   font-size: var(--type-body-xs-size);
   background-color: var(--bg-color-lightgrey);
-  padding: var(--spacing-xxs) var(--spacing-s);
+  padding: var(--spacing-xs) var(--spacing-s);
   border: solid 1px var(--bg-color-grey-2);
   border-radius: var(--image-border-radius-l);
 }

--- a/blocks/faq/faq.css
+++ b/blocks/faq/faq.css
@@ -52,6 +52,10 @@ main .faq .filter-controls {
   display: flex;
   font-size: var(--type-body-xs-size);
   font-weight: 700;
+  background-color: var(--bg-color-lightgrey);
+  padding: var(--spacing-xxs) var(--spacing-s);
+  border: solid 1px var(--bg-color-grey-2);
+  border-radius: var(--image-border-radius-l);
 }
 
 main .faq .filter-control label {

--- a/blocks/faq/faq.css
+++ b/blocks/faq/faq.css
@@ -10,6 +10,30 @@ main .faq dt > a {
   line-height: var(--type-heading-s-lh);
 }
 
+main .faq .category {
+  font-size: var(--type-body-xs-size);
+  font-weight: 700;
+  line-height: var(--type-body-xs-lh);
+  margin: 0 var(--spacing-xxxs);
+  padding: var(--spacing-xxxs) var(--spacing-xxs);
+  border-radius: 12px;
+  background-color: var(--bg-color-grey-2);
+  color: currentcolor;
+}
+
+main .faq .category.style-1 {
+  background-color: var(--brand-color-purple);
+  color: var(--color-white);
+}
+
+main .faq .category.style-2 {
+  background-color: var(--brand-color-pink);
+  color: var(--color-white);}
+
+main .faq .category.style-3 {
+  background-color: var(--brand-color-green-yellow);
+}
+
 main .faq dd {
   font-size: var(--type-body-s-size);
   line-height: var(--type-body-s-lh);
@@ -17,4 +41,26 @@ main .faq dd {
 
 body.guides-template main .faq dt a.anchor-link:any-link::before {
   top: 0;
+}
+
+main .faq .filter-controls {
+  display: flex;
+  font-size: var(--type-body-xs-size);
+}
+
+main .faq .filter-control label {
+  cursor: pointer;
+}
+
+main .faq .filter-control input[type="checkbox"] {
+  display: none;
+}
+
+main .faq .filter-control input[type="checkbox"]:not(:checked) + label {
+  background-color: var(--color-bg);
+  color: currentcolor;
+}
+
+main .faq .hidden-by-filter {
+  display: none;
 }

--- a/blocks/faq/faq.js
+++ b/blocks/faq/faq.js
@@ -23,8 +23,15 @@ function getSelectedFilterValues($block) {
 }
 
 function updateSearchParams($block) {
-  const filters = getSelectedFilterValues($block);
+  let filters = getSelectedFilterValues($block);
   const url = new URL(window.location.href);
+  if (filters.includes('All')) {
+    // omit search parms in case of 'all'
+    filters = [];
+  } else if (filters.length === 0) {
+    // no filters selected, add 'None' filter
+    filters.push('None');
+  }
   const usp = new URLSearchParams(filters.map((v) => ['filter', v]));
   url.search = usp.toString();
   window.history.pushState(null, '', url);
@@ -49,7 +56,6 @@ function buildCategoryLabels(categories) {
     .map((cat) => {
       if (!styles[cat]) {
         const style = (Object.keys(styles).length % 4) + 1;
-        console.log(`Assigning style ${style} to category ${cat}`);
         styles[cat] = style;
       }
       const span = document.createElement('span');
@@ -69,7 +75,9 @@ function buildFilterControl(cat, $block) {
   checkbox.id = `filter-${cat}`;
   checkbox.value = cat;
   checkbox.type = 'checkbox';
-  checkbox.setAttribute('checked', urlFilters.length > 0 ? urlFilters.includes(cat) : true);
+  if (!urlFilters.includes('None') && urlFilters.includes(cat)) {
+    checkbox.checked = true;
+  }
   control.append(checkbox);
 
   control.addEventListener('click', () => {

--- a/blocks/faq/faq.js
+++ b/blocks/faq/faq.js
@@ -1,11 +1,121 @@
 import { addAnchorLink } from '../../scripts/scripts.js';
 
+const categoryColors = {
+  build: 1,
+  publish: 2,
+  launch: 3,
+};
+
 function autoLink(string) {
   const pattern = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:https?):\/\/[-A-Z0-9+\u0026\u2019@#/%?=()~_|!:,.;]*[-A-Z0-9+\u0026@#/%=~()_|])/gi;
   return string.replace(pattern, '$1<a href="$2">$2</a>');
 }
 
+function getCategoryFiltersFromUrl() {
+  return new URLSearchParams(window.location.search).getAll('filter');
+}
+
+function getSelectedFilterValues($block) {
+  const selectedFilters = [...$block.querySelectorAll('input[name="filter"]:checked')]
+    .map((cb) => cb.id.substring(7)) // remove 'filter-' prefix
+    .filter((filter) => filter !== 'All'); // ignore 'all'
+  if (selectedFilters.length === $block.querySelectorAll('input[name="filter"]:not(#filter-All)').length) {
+    // all filters selected, simply use 'All'
+    return ['All'];
+  }
+  return selectedFilters;
+}
+
+function updateSearchParams($block) {
+  const filters = getSelectedFilterValues($block);
+  const url = new URL(window.location.href);
+  const usp = new URLSearchParams(filters.map((v) => ['filter', v]));
+  url.search = usp.toString();
+  window.history.pushState(null, '', url);
+}
+
+function filterResults(filters, $block) {
+  $block.querySelectorAll('dt').forEach((dt) => {
+    const cats = [...dt.querySelectorAll('.category')].map((cat) => cat.textContent.trim());
+    if (filters.includes('All')
+      || filters.some((f) => cats.includes(f))) {
+      dt.classList.remove('hidden-by-filter');
+      dt.nextElementSibling.classList.remove('hidden-by-filter');
+    } else {
+      dt.classList.add('hidden-by-filter');
+      dt.nextElementSibling.classList.add('hidden-by-filter');
+    }
+  });
+}
+
+function buildCategoryLabels(categories) {
+  return categories
+    .map((cat) => {
+      const span = document.createElement('span');
+      span.className = `category style-${categoryColors[cat.toLowerCase()] || 0}`;
+      span.textContent = cat;
+      return span;
+    });
+}
+
+function buildFilterControl(cat, $block) {
+  const urlFilters = getCategoryFiltersFromUrl();
+  const control = document.createElement('div');
+  control.classList.add('filter-control');
+
+  const checkbox = document.createElement('input');
+  checkbox.name = 'filter';
+  checkbox.id = `filter-${cat}`;
+  checkbox.value = cat;
+  checkbox.type = 'checkbox';
+  checkbox.setAttribute('checked', urlFilters.length > 0 ? urlFilters.includes(cat) : true);
+  control.append(checkbox);
+
+  control.addEventListener('click', () => {
+    // toggle checkbox
+    checkbox.checked = !checkbox.checked;
+    const { checked } = checkbox;
+    if (cat === 'All') {
+      // 'all' filter checked, check all other filters
+      $block.querySelectorAll('input[name="filter"]').forEach((cb) => {
+        cb.checked = checked;
+      });
+    } else if (!checked) {
+      // if any filter is unchecked, also uncheck 'all' filter
+      $block.querySelector('input[name="filter"]#filter-All').checked = false;
+    } else if ($block.querySelectorAll('input[name="filter"]:checked').length === $block.querySelectorAll('input[name="filter"]').length - 1) {
+      // if all filters are checked, also check 'all' filter
+      $block.querySelector('input[name="filter"]#filter-All').checked = true;
+    }
+    filterResults(getSelectedFilterValues($block), $block);
+    updateSearchParams($block);
+  });
+
+  const label = document.createElement('label');
+  label.textContent = cat;
+  label.htmlFor = cat;
+  label.className = `category style-${categoryColors[cat.toLowerCase()] || 0}`;
+  control.append(label);
+
+  return control;
+}
+
+function buildCategoryFilters(categories, $block) {
+  const controls = document.createElement('div');
+  controls.classList.add('filter-controls');
+  controls.textContent = 'Category:';
+
+  // 'all' filter
+  controls.append(buildFilterControl('All', $block));
+
+  controls.append(...categories
+    .map((category) => buildFilterControl(category, $block)));
+
+  return controls;
+}
+
 export default async function decorateFaq($block) {
+  const allCats = [];
   const source = new URL($block.querySelector('a').href).pathname;
   const resp = await fetch(source);
   const json = await resp.json();
@@ -22,9 +132,23 @@ export default async function decorateFaq($block) {
     const titleLink = $dt.querySelector('.anchor-link');
     if (titleLink) titleLink.classList.add('link-highlight-colorful-effect-2');
     $dd.innerHTML = answer;
+    if (row.Category) {
+      const categories = row.Category.split(',').map((cat) => cat.trim());
+      // remember category and add labels
+      allCats.push(...categories);
+      $dt.append(...buildCategoryLabels(categories, $block));
+    }
     $dl.append($dt, $dd);
   });
+  if (allCats.length > 0) {
+    const uniqueCats = [...new Set(allCats)]; // dedupe categories
+    $block.append(buildCategoryFilters(uniqueCats, $block));
+  }
   $block.append($dl);
+  const prefilters = getCategoryFiltersFromUrl();
+  if (prefilters.length > 0) {
+    filterResults(prefilters, $block);
+  }
 
   const selected = document.getElementById(window.location.hash.slice(1));
   if (selected) {

--- a/blocks/faq/faq.js
+++ b/blocks/faq/faq.js
@@ -1,10 +1,6 @@
 import { addAnchorLink } from '../../scripts/scripts.js';
 
-const categoryColors = {
-  build: 1,
-  publish: 2,
-  launch: 3,
-};
+const styles = {};
 
 function autoLink(string) {
   const pattern = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:https?):\/\/[-A-Z0-9+\u0026\u2019@#/%?=()~_|!:,.;]*[-A-Z0-9+\u0026@#/%=~()_|])/gi;
@@ -51,8 +47,13 @@ function filterResults(filters, $block) {
 function buildCategoryLabels(categories) {
   return categories
     .map((cat) => {
+      if (!styles[cat]) {
+        const style = (Object.keys(styles).length % 4) + 1;
+        console.log(`Assigning style ${style} to category ${cat}`);
+        styles[cat] = style;
+      }
       const span = document.createElement('span');
-      span.className = `category style-${categoryColors[cat.toLowerCase()] || 0}`;
+      span.className = `category style-${styles[cat] || 0}`;
       span.textContent = cat;
       return span;
     });
@@ -94,7 +95,7 @@ function buildFilterControl(cat, $block) {
   const label = document.createElement('label');
   label.textContent = cat;
   label.htmlFor = cat;
-  label.className = `category style-${categoryColors[cat.toLowerCase()] || 0}`;
+  label.className = `category style-${styles[cat] || 0}`;
   control.append(label);
 
   return control;
@@ -103,7 +104,7 @@ function buildFilterControl(cat, $block) {
 function buildCategoryFilters(categories, $block) {
   const controls = document.createElement('div');
   controls.classList.add('filter-controls');
-  controls.textContent = 'Category:';
+  controls.textContent = 'Categories:';
 
   // 'all' filter
   controls.append(buildFilterControl('All', $block));

--- a/blocks/faq/faq.js
+++ b/blocks/faq/faq.js
@@ -75,7 +75,7 @@ function buildFilterControl(cat, $block) {
   checkbox.id = `filter-${cat}`;
   checkbox.value = cat;
   checkbox.type = 'checkbox';
-  if (!urlFilters.includes('None') && urlFilters.includes(cat)) {
+  if (urlFilters.length === 0 || (!urlFilters.includes('None') && urlFilters.includes(cat))) {
     checkbox.checked = true;
   }
   control.append(checkbox);


### PR DESCRIPTION
Add opt-in category labels and allow filtering. If a sheet has a `Category` column with values in it, the FAQ block will add category tags to those entries, and allow the user to filter for certain categories.

Before: https://main--helix-website--adobe.aem.page/drafts/rofe/cat
After: https://faq-cats--helix-website--adobe.aem.page/drafts/rofe/cat?filter=Lorem