### PR TITLE
chore: loading images as img tag rather than links in ./blog

### DIFF
--- a/blocks/feed/feed.css
+++ b/blocks/feed/feed.css
@@ -37,6 +37,10 @@
   background-color: white;
 }
 
+.blog-item.latest .image-wrapper {
+  width: 100%;
+}
+
 .blog-item:not(.blog-item.latest):hover {
   box-shadow: 0 8px 16px rgba(0 0 0 / 40%);
 }

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -1,3 +1,4 @@
+import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 import {
   createTag,
   loadFeedData,
@@ -73,9 +74,7 @@ export async function fetchBlogContent(url) {
       const { pathname } = linkSrc;
       if (isImgUrl(pathname)) {
         const imgName = pathname.substring(pathname.lastIndexOf('/') + 1, pathname.lastIndexOf('.'));
-        const img = createTag('img', {
-          src: pathname, alt: imgName, width: '100%', loading: 'eager',
-        });
+        const img = createOptimizedPicture(pathname, imgName);
         link.parentElement.classList.add('image-wrapper');
         link.replaceWith(img);
       }

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -51,7 +51,7 @@ export async function renderFeed(block) {
 }
 
 function isImgUrl(url) {
-  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url)
+  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);
 }
 
 // logic to render blog list home page
@@ -69,11 +69,13 @@ export async function fetchBlogContent(url) {
     });
     // render images as img tags rather than linka
     doc.querySelectorAll('a').forEach((link) => {
-      const url = new URL(link.href);
-      const pathname = url.pathname;
-      if (isImgUrl(url)) {
-        const imgName = pathname?.substring(pathname?.lastIndexOf("/")+1, pathname?.lastIndexOf("."));
-        const img = createTag('img', { src: pathname, alt: imgName, width: '100%', loading: 'eager' });
+      const linkSrc = new URL(link.href);
+      const { pathname } = linkSrc;
+      if (isImgUrl(pathname)) {
+        const imgName = pathname.substring(pathname.lastIndexOf('/') + 1, pathname.lastIndexOf('.'));
+        const img = createTag('img', {
+          src: pathname, alt: imgName, width: '100%', loading: 'eager',
+        });
         link.parentElement.classList.add('image-wrapper');
         link.replaceWith(img);
       }
@@ -107,7 +109,6 @@ export async function renderBlog(block) {
     // eslint-disable-next-line max-len
     const truncatedContent = latestBlogContent.substring(0, Math.floor(latestBlogContent.length * 0.75));
     latestBlogItem.innerHTML = truncatedContent;
-    
   }
 
   const readMoreButton = createTag('a', { href: latestBlog.path, class: 'read-more button primary large' }, 'Read More');

--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -50,6 +50,10 @@ export async function renderFeed(block) {
   block.appendChild(parentDiv);
 }
 
+function isImgUrl(url) {
+  return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url)
+}
+
 // logic to render blog list home page
 export async function fetchBlogContent(url) {
   try {
@@ -62,6 +66,17 @@ export async function fetchBlogContent(url) {
       const newHeading = document.createElement(nextLevel);
       newHeading.innerHTML = heading.innerHTML;
       heading.replaceWith(newHeading);
+    });
+    // render images as img tags rather than linka
+    doc.querySelectorAll('a').forEach((link) => {
+      const url = new URL(link.href);
+      const pathname = url.pathname;
+      if (isImgUrl(url)) {
+        const imgName = pathname?.substring(pathname?.lastIndexOf("/")+1, pathname?.lastIndexOf("."));
+        const img = createTag('img', { src: pathname, alt: imgName, width: '100%', loading: 'eager' });
+        link.parentElement.classList.add('image-wrapper');
+        link.replaceWith(img);
+      }
     });
     const content = doc.querySelector('body > main > div');
     return content ? content.innerHTML : '';
@@ -92,6 +107,7 @@ export async function renderBlog(block) {
     // eslint-disable-next-line max-len
     const truncatedContent = latestBlogContent.substring(0, Math.floor(latestBlogContent.length * 0.75));
     latestBlogItem.innerHTML = truncatedContent;
+    
   }
 
   const readMoreButton = createTag('a', { href: latestBlog.path, class: 'read-more button primary large' }, 'Read More');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Treating images as <img> tags than <a>

## Related Issue

fix: #787 

## Motivation and Context

To display images

## How Has This Been Tested?

Testing manually

Before 
![image](https://github.com/user-attachments/assets/f2ef18c3-bc15-425c-87f7-785a350d2819)

After 
![image](https://github.com/user-attachments/assets/915daa8f-3b54-4bf9-8b32-33443c9dc853)

Before: https://main--helix-website--adobe.aem.live/blog
After: https://blog-feed-images--helix-website--adobe.aem.live/blog

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
