### PR TITLE
fix: append to search params

### DIFF
--- a/tools/oversight/elements/conversion-tracker.js
+++ b/tools/oversight/elements/conversion-tracker.js
@@ -49,7 +49,7 @@ export default class ConversionTracker extends HTMLElement {
     Array.from(usp.entries())
       .filter(([key]) => isKnownFacet(key))
       .forEach(([key, value]) => {
-        usp.set(`conversion.${key}`, value);
+        usp.append(`conversion.${key}`, value);
       });
     // remove all filter keys
     Array.from(usp.keys())


### PR DESCRIPTION
As discussed in Slack, only one click.source was previously allowed.  A potential issue I see with this fix is that is seems to look for events matching ALL of the click.source values (AND logic instead of OR logic), in other words the user clicked multiple times in the same sampled page view, which is likely not common and results in low numbers.  I did not go deeper, wanted to discuss the intent here and am open to the idea that we only want one click.source and should not try to accommodate multiple.

## How Has This Been Tested?

Tested at `engagement-custom--helix-website--adobe.hlx.page` with the usual path and querystring params.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
