### PR TITLE
feat: add experiment facets to oversight

### DIFF
--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -194,6 +194,8 @@
               <dd>Largest Contentful Paint</dd>
               <dt>redirect</dt>
               <dd>Redirect</dd>
+              <dt>experiment</dt>
+              <dd>Experiment</dd>
             </dl>
           </list-facet>
           <literal-facet facet="click.source" drilldown="list.html">
@@ -367,6 +369,14 @@
 
           <list-facet facet="redirect.target">
             <legend>Redirect Hops</legend>
+          </list-facet>
+
+          <list-facet facet="experiment.source">
+            <legend>Experiment ID</legend>
+          </list-facet>
+
+          <list-facet facet="experiment.target">
+            <legend>Selected Variant</legend>
           </list-facet>
         </facet-sidebar>
       </div>


### PR DESCRIPTION
## Description

Adds the experiment checkpoint as well as source/target facets.

## Related Issue

Fix #803 

## Motivation and Context

allows comparing CWV impact of experiments, as well as drilling down on other checkpoints (clicks, etc.) when experiment is running.

## How Has This Been Tested?

https://main--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=www.aem.live&filter=&view=year&=performance&checkpoint=click&checkpoint=experiment&experiment.source=short-home&experiment.target=challenger-1&domainkey=&conversion.checkpoint=click

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
