### PR TITLE
fix: published doc search source

### DIFF
--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -58,7 +58,7 @@ export default async function decorate(block) {
   const skipLink = createTag('a', { class: 'skip-link', href: '#search-results' }, 'Skip to results');
   const searchBlock = buildBlock('doc-search', [[
     '<a href="/docpages-index.json">Search</a>',
-    '<a href="/drafts/fkakatie/faq">FAQ</a>',
+    '<a href="/docs/faq">FAQ</a>',
   ]]);
   searchBlock.dataset.resultsContainerClass = 'results-wrapper';
   aside.prepend(docButton);


### PR DESCRIPTION
unpublished resource 404ing on when using the `side-navigation` block search feature.

## Description

before: https://www.aem.live/developer/tutorial
after: https://side-nav-src--helix-website--adobe.aem.page/developer/tutorial
