### PR TITLE
fix: avoid mutation observer infinite looping in rum oversight

### DIFF
--- a/tools/oversight/elements/number-format.js
+++ b/tools/oversight/elements/number-format.js
@@ -11,15 +11,14 @@ export default class NumberFormat extends HTMLElement {
 
   connectedCallback() {
     this.mutationObserver = new MutationObserver(() => {
-      this.updateState();
+      const fv = this.querySelector('span.formatted-value');
+      if (!fv) this.updateState();
     });
     this.updateState();
     this.mutationObserver.observe(this, { childList: true });
   }
 
   updateState() {
-    // stop observing while updating
-    this.mutationObserver.disconnect();
     const isPureNumber = !!this.textContent.trim().match(/^\d+(\.\d+)?$/);
     const titleValue = parseFloat((this.getAttribute('title') || '').replace(/ .*/g, ''), 10);
     const contentValue = parseFloat(this.textContent, 10);
@@ -31,16 +30,20 @@ export default class NumberFormat extends HTMLElement {
     const total = parseInt(this.getAttribute('total'), 10);
     const precision = parseInt(this.getAttribute('precision'), 10);
     const fuzzy = this.getAttribute('fuzzy') !== 'false';
+    const fv = document.createElement('span');
+    fv.classList.add('formatted-value');
     if (Number.isNaN(number)) {
-      this.textContent = '-';
+      fv.textContent = '-';
       this.setAttribute('title', 'no data available');
+      this.replaceChildren(fv);
     } else {
-      this.textContent = roundToConfidenceInterval(
+      fv.textContent = roundToConfidenceInterval(
         number,
         Number.isNaN(sampleSize) ? 0 : sampleSize,
         precision,
         fuzzy,
       );
+      this.replaceChildren(fv);
 
       // set the title to the original number
       this.title = number;
@@ -62,7 +65,5 @@ export default class NumberFormat extends HTMLElement {
     if (this.getAttribute('trend')) {
       this.title += ` and ${this.getAttribute('trend')}`;
     }
-    // resume observing
-    this.mutationObserver.observe(this, { childList: true });
   }
 }


### PR DESCRIPTION
## Description

When adding/removing facets in the sidebar, the browser frequently becomes hung. Was able to trace it to the mutation observer, which seems to infinite loop. Basically, it seems like even though we are calling disconnect, it doesn't actually get disconnected immediately. Fixed by using a span inside the element for storing the formatted value. When the element is updated externally, that happens with a simple `.textConent = ${value}`, so this should be safe and works per my testing.

I considered just using a set timeout after disconnecting, which works too. Not sure which approach I like better, so open to thoughts here.

## Related Issue

https://cq-dev.slack.com/archives/C07198KKQ07/p1744313769838479

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

test urls, add domain key and add/remove facets vis sidebar to see the difference.

Before: https://main--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=www.ups.com&filter=&view=custom&startDate=2025-04-17&endDate=2025-04-18&=performance&domainkey=&conversion.checkpoint=click

After: https://rum-oversight-hangs--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=www.ups.com&filter=&view=custom&startDate=2025-04-17&endDate=2025-04-18&=performance&domainkey=&conversion.checkpoint=click

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
