### PR TITLE
fix: bring back faq heading anchors

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -219,9 +219,7 @@ export function addHeadingAnchorLink(elem) {
 }
 
 export function decorateGuideTemplateHeadings(main) {
-  const contentArea = main.querySelector('.section.content');
-  if (!contentArea) return;
-  const contentSections = contentArea.querySelectorAll(
+  const contentSections = main.querySelectorAll(
     '.default-content-wrapper',
   );
   if (!contentSections) return;


### PR DESCRIPTION
Since the refactoring of the FAQ page, we no longer have anchor links on the headings.

https://main--helix-website--adobe.aem.page/docs/faq
vs
https://faq-headings--helix-website--adobe.aem.page/docs/faq