### PR TITLE
fix: order of blog posts

### DIFF
--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -93,7 +93,14 @@ export async function renderBlog(block) {
     return;
   }
   const blogIndex = window.blogindex.data;
-  blogIndex.reverse();
+
+  // Sort blogs by publication date in descending order
+  blogIndex.sort((a, b) => {
+    const dateA = new Date(a.publicationDate);
+    const dateB = new Date(b.publicationDate);
+    return dateA - dateB;
+  });
+
   // Skip if block has favorite class
   if (block.classList.contains('favorite')) {
     return;
@@ -134,14 +141,14 @@ export async function renderBlog(block) {
     }
   }
 
-  // Get the latest blog
-  const latestBlog = blogIndex[0];
+  // Get the latest blog (newest by publication date)
+  const latestBlog = blogIndex[blogIndex.length - 1];
   if (!leftContainer.querySelector('.blog-item.latest')) {
     const latestBlogItem = createTag('div', { class: 'blog-item latest' });
     const latestBlogContent = await fetchBlogContent(latestBlog.path);
     if (latestBlogContent) {
-      // eslint-disable-next-line max-len
-      const truncatedContent = latestBlogContent.substring(0, Math.floor(latestBlogContent.length * 0.80));
+      const contentLength = latestBlogContent.length;
+      const truncatedContent = latestBlogContent.substring(0, Math.floor(contentLength * 0.80));
       latestBlogItem.innerHTML = truncatedContent;
     }
 
@@ -154,10 +161,13 @@ export async function renderBlog(block) {
     leftContainer.appendChild(latestBlogItem);
   }
 
-  // Get next 5 blogs in newest to oldest order
-  const startIndex = 0;
-  const endIndex = Math.min(startIndex + 5, blogIndex.length);
+  // Get next 5 blogs in newest to oldest order by publication date
+  const startIndex = Math.max(0, blogIndex.length - 6);
+  // Exclude the latest blog which is shown in left container
+  const endIndex = blogIndex.length - 1;
+  // Reverse to get newest to oldest
   const recentBlogs = blogIndex.slice(startIndex, endIndex).reverse();
+
   recentBlogs.forEach((page) => {
     const blogItem = createTag('div', { class: 'blog-item' });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the order of blog posts on https://www.aem.live/blog

## Related Issue
#827 

## Motivation and Context
Currently the order seems to be reversed. Fix needed to display blogs in descending order of publication date.

## How Has This Been Tested?
The blogs now appear in the right expected order

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
