### PR TITLE
Column Block - Fix image & Text formatting.

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -261,7 +261,7 @@ main.without-full-width-hero .section.content .columns-wrapper {
   /* others */
   .columns.two.contained > div {
     max-width: var(--grid-desktop-container-width);
-    grid-template-columns: 50% 50%;
+    grid-template-columns: 1fr 1fr;
     grid-gap: var(--spacing-xxl);
   }
 

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -71,7 +71,16 @@ export default function decorate(block) {
       cell.classList.add('columns-content');
       const wrapper = document.createElement('div');
       wrapper.className = 'columns-content-wrapper';
-      while (cell.firstChild) wrapper.append(cell.firstChild);
+      while (cell.firstChild) {
+        const firstChild = cell.firstChild;
+        if (firstChild.nodeType === Node.TEXT_NODE) {
+          const par = document.createElement('p');
+          par.append(firstChild);
+          wrapper.append(par);
+        } else {
+          wrapper.append(firstChild);
+        }
+      }
       cell.append(wrapper);
 
       // colored icons

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -72,7 +72,7 @@ export default function decorate(block) {
       const wrapper = document.createElement('div');
       wrapper.className = 'columns-content-wrapper';
       while (cell.firstChild) {
-        const firstChild = cell.firstChild;
+        const { firstChild } = cell;
         if (firstChild.nodeType === Node.TEXT_NODE) {
           const par = document.createElement('p');
           par.append(firstChild);


### PR DESCRIPTION
## Description

Changed two-column view to use `fr` rather than %. Also if the column only contains one child (that is a text node), wrap it in a `p` tag to get correct formatting.

## Related Issue

#852 

## Motivation and Context

Fix the visual

## How Has This Been Tested?

Visually validated the changes on the problem page.

Test URL: https://bug-columns-img-width--helix-website--adobe.aem.live/docs/authentication-setup-authoring

## Screenshots:

![Configuring_Authentication_for_Authors](https://github.com/user-attachments/assets/168b03e7-7d2e-4bd5-aa86-bffaed2ba500)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
