### PR TITLE
feat: add helix-reviews to releases block

### DIFF
--- a/blocks/releases/releases.css
+++ b/blocks/releases/releases.css
@@ -39,6 +39,10 @@
   background-color: #edd1ff;
 }
 
+.releases .release-helix-reviews {
+  background-color: #ffe4d4;
+}
+
 .releases .release {
   padding: 16px 32px 32px;
   margin: 16px 0;
@@ -82,6 +86,7 @@
 .releases .helix-config-service .release-helix-config-service,
 .releases .aem-lib .release-aem-lib,
 .releases .franklin-sidekick-library .release-franklin-sidekick-library,
-.releases .aem-certificate-rotation .release-aem-certificate-rotation {
+.releases .aem-certificate-rotation .release-aem-certificate-rotation,
+.releases .helix-reviews .release-helix-reviews {
   display: block;
 }

--- a/blocks/releases/releases.js
+++ b/blocks/releases/releases.js
@@ -23,6 +23,7 @@ const displayNames = {
   'aem-lib': 'AEM Library',
   'helix-sidekick-extension': 'Sidekick Extension (legacy)',
   'aem-certificate-rotation': 'Infrastructure Updates',
+  'helix-reviews': 'AEM Review System',
 };
 
 function createRelease(release) {


### PR DESCRIPTION
## Summary
- Added helix-reviews repository to the releases block display configuration
- The repository has releases in the AEM release feed but wasn't showing in the UI
- Now displays as "AEM Review System" in the releases filter

## Details
The helix-reviews repository has releases available in the feed at https://aem-release-feed.david8603.workers.dev/ (verified with the recent v1.0.0 release), but it wasn't appearing in the releases block because it was missing from the `displayNames` configuration object.

This change adds the repository to the configuration so users can view and filter helix-reviews releases alongside other AEM project releases.

## Test Plan

**BEFORE (main branch - helix-reviews not visible):**
https://main--helix-website--adobe.aem.live/docs/release-history

**AFTER (this PR - helix-reviews visible as "AEM Review System"):**
https://add-helix-reviews-to-releases--helix-website--adobe.aem.live/docs/release-history

On the AFTER URL, you should see "AEM Review System" as a new checkbox option in the filter controls at the top of the releases list, and when checked, it will show the helix-reviews releases (like v1.0.0 from today).

🤖 Generated with [Claude Code](https://claude.ai/code)