### PR TITLE
chore: mention teams in the default EAT banner message

### DIFF
--- a/blocks/labs/labs.js
+++ b/blocks/labs/labs.js
@@ -12,7 +12,7 @@ export default function decorate(block) {
   }
   if (parts.length === 1) {
     parts.unshift('Early-access technology');
-    parts[1] = `Ask us about this feature from the ${parts[1]} labs on your Slack channel!`;
+    parts[1] = `Ask us about this feature from the ${parts[1]} labs on your Teams or Slack channel!`;
   }
   [header.textContent, block.innerHTML] = parts;
   block.prepend(header);


### PR DESCRIPTION
Before: https://main--helix-website--adobe.aem.live/developer/content-fragment-overlay
After: https://labs-teams--helix-website--adobe.aem.live/developer/content-fragment-overlay
