### PR TITLE
fix: streamline template selection logic in ue trial

### DIFF
--- a/blocks/ue-trial/ue-trial.js
+++ b/blocks/ue-trial/ue-trial.js
@@ -454,8 +454,9 @@ async function buildForm(block) {
   const templateGrid = createTag('div', { class: 'template-grid' });
 
   templates.forEach((template, index) => {
+    const isDefault = index === 0;
     const templateCard = createTag('div', {
-      class: `template-card ${index === 0 ? 'selected' : ''}`,
+      class: `template-card ${isDefault ? 'selected' : ''}`,
       'data-value': template.value,
     });
 
@@ -466,7 +467,7 @@ async function buildForm(block) {
       name: 'template',
       value: template.value,
       required: 'true',
-      checked: index === 0, // Default to first template
+      ...(isDefault && { checked: true }), // Only add checked attribute when true
     });
 
     // Create label for the radio button
@@ -516,11 +517,18 @@ async function buildForm(block) {
         card.classList.remove('selected');
       });
 
+      // Uncheck all radio buttons and remove checked attribute
+      templateGrid.querySelectorAll('input[type="radio"]').forEach((radio) => {
+        radio.checked = false;
+        radio.removeAttribute('checked');
+      });
+
       // Add selected class to clicked card
       templateCard.classList.add('selected');
 
-      // Check the radio button
+      // Check the radio button and add checked attribute
       radioInput.checked = true;
+      radioInput.setAttribute('checked', 'true');
     });
 
     // Radio button change handler for visual feedback
@@ -531,8 +539,18 @@ async function buildForm(block) {
           card.classList.remove('selected');
         });
 
+        // Uncheck all radio buttons and remove checked attribute
+        templateGrid.querySelectorAll('input[type="radio"]').forEach((radio) => {
+          radio.checked = false;
+          radio.removeAttribute('checked');
+        });
+
         // Add selected class to this card
         templateCard.classList.add('selected');
+
+        // Check this radio button and add checked attribute
+        radioInput.checked = true;
+        radioInput.setAttribute('checked', 'true');
       }
     });
 


### PR DESCRIPTION
UE Trial form submits wrong default template

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the radio button handling to ensure checked attributes are only set when necessary.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

fixes #900 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Test URL: https://fix-template-selection--helix-website--adobe.aem.live/developer/ue-trial

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
