### PR TITLE
feat(blog): add blog archive page

### DIFF
--- a/blocks/blog-archive/blog-archive.css
+++ b/blocks/blog-archive/blog-archive.css
@@ -1,0 +1,28 @@
+
+.blog-archive {
+  margin: 2rem;
+}
+
+.blog-archive h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.blog-archive h3 {
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.blog-archive ul {
+  list-style: none;
+  padding: 0;
+}
+
+.blog-archive li {
+  margin-bottom: 0.5rem;
+}
+
+.blog-archive .post-date {
+  color: #888;
+  margin-right: 1rem;
+}

--- a/blocks/blog-archive/blog-archive.js
+++ b/blocks/blog-archive/blog-archive.js
@@ -1,0 +1,62 @@
+
+import { readBlockConfig } from '../../scripts/lib-franklin.js';
+
+function groupPosts(posts) {
+  const grouped = {};
+  posts.forEach((post) => {
+    const date = new Date(post.publicationDate * 1000);
+    const year = date.getFullYear();
+    const month = date.toLocaleString('default', { month: 'long' });
+    if (!grouped[year]) {
+      grouped[year] = {};
+    }
+    if (!grouped[year][month]) {
+      grouped[year][month] = [];
+    }
+    grouped[year][month].push(post);
+  });
+  return grouped;
+}
+
+function renderArchive(groupedPosts, block) {
+  const years = Object.keys(groupedPosts).sort().reverse();
+  years.forEach((year) => {
+    const yearEl = document.createElement('h2');
+    yearEl.textContent = year;
+    block.append(yearEl);
+    const months = Object.keys(groupedPosts[year]).sort((a, b) => {
+      const aDate = new Date(`${a} 1, 2000`);
+      const bDate = new Date(`${b} 1, 2000`);
+      return bDate - aDate;
+    });
+    months.forEach((month) => {
+      const monthEl = document.createElement('h3');
+      monthEl.textContent = month;
+      block.append(monthEl);
+      const postList = document.createElement('ul');
+      groupedPosts[year][month].forEach((post) => {
+        const postItem = document.createElement('li');
+        const postDate = new Date(post.publicationDate * 1000);
+        const dateString = postDate.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit' });
+        postItem.innerHTML = `<span class="post-date">${dateString}</span><a href="${post.path}">${post.title}</a> by ${post.author}`;
+        postList.append(postItem);
+      });
+      block.append(postList);
+    });
+  });
+}
+
+export default async function decorate(block) {
+  const config = readBlockConfig(block);
+  block.innerHTML = '';
+
+  if (window.blogindex && window.blogindex.loaded) {
+    const groupedPosts = groupPosts(window.blogindex.data);
+    renderArchive(groupedPosts, block);
+  } else {
+    document.addEventListener('dataset-ready', () => {
+      const groupedPosts = groupPosts(window.blogindex.data);
+      renderArchive(groupedPosts, block);
+    });
+  }
+}

--- a/blog/archive.html
+++ b/blog/archive.html
@@ -1,0 +1,19 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Blog Archive</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="/scripts/scripts.js" type="module"></script>
+    <link rel="stylesheet" href="/styles/styles.css" />
+  </head>
+  <body>
+    <header></header>
+    <main>
+      <div>
+        <div class="blog-archive"></div>
+      </div>
+    </main>
+    <footer></footer>
+  </body>
+</html>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -709,6 +709,10 @@ async function loadLazy(doc) {
   await loadBlocks(main);
   addBlockLevelInViewAnimation(main);
 
+  if (main.querySelector('.blog-archive')) {
+    loadBlogData();
+  }
+
   const { hash } = window.location;
   if (hash) {
     setTimeout(() => {


### PR DESCRIPTION
This PR introduces a new blog archive page that lists all blog posts, grouped by year and month. It includes a new 'blog-archive' block and the necessary JavaScript to fetch and render the data. This work was AI-generated by Gemini.