### PR TITLE
feat: Add blog archive page with year/month grouping

### DIFF
--- a/blocks/blog-archive/blog-archive.css
+++ b/blocks/blog-archive/blog-archive.css
@@ -1,0 +1,57 @@
+.blog-archive-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  font-family: var(--body-font-family);
+}
+
+.blog-archive-year {
+  font-size: 1.8rem;
+  margin: 2rem 0 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--color-gray-200);
+  color: var(--color-gray-800);
+}
+
+.blog-archive-month {
+  font-size: 1.4rem;
+  margin: 1.5rem 0 0.5rem;
+  color: var(--color-gray-700);
+}
+
+.blog-archive-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0.5rem 0 1.5rem;
+}
+
+.blog-archive-item {
+  margin: 0.5rem 0;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--color-gray-100);
+}
+
+.blog-archive-item:last-child {
+  border-bottom: none;
+}
+
+.blog-archive-link {
+  text-decoration: none;
+  color: var(--color-accent);
+  font-weight: 500;
+  display: block;
+  padding: 0.25rem 0;
+  transition: color 0.2s ease;
+}
+
+.blog-archive-link:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
+/* Responsive design */
+@media (width >= 600px) {
+  .blog-archive-container {
+    padding: 30px;
+  }
+}

--- a/blocks/blog-archive/blog-archive.js
+++ b/blocks/blog-archive/blog-archive.js
@@ -1,0 +1,92 @@
+import { createTag, getBlogArchiveData, loadBlogData } from '../../scripts/scripts.js';
+
+// Function to render the blog archive
+export function renderBlogArchive(block) {
+  if (!block) {
+    return;
+  }
+
+  // Check if blog index is loaded
+  if (!window.blogindex?.loaded) {
+    // Wait for blog index to load
+    document.addEventListener('dataset-ready', () => {
+      renderBlogArchive(block);
+    });
+    return;
+  }
+
+  // Get the grouped blog archive data
+  const archiveData = getBlogArchiveData();
+
+  if (!archiveData || Object.keys(archiveData).length === 0) {
+    block.innerHTML = '<p>No blog posts found.</p>';
+    return;
+  }
+
+  // Sort years in descending order (newest first)
+  const years = Object.keys(archiveData).sort((a, b) => b - a);
+
+  // Create container for the archive
+  const archiveContainer = createTag('div', { class: 'blog-archive-container' });
+
+  years.forEach((year) => {
+    // Create year heading
+    const yearHeading = createTag('h2', { class: 'blog-archive-year' }, year);
+    archiveContainer.appendChild(yearHeading);
+
+    // Get months for this year and sort in descending order (newest first)
+    const months = Object.keys(archiveData[year]).sort((a, b) => b - a);
+
+    months.forEach((month) => {
+      // Create month heading
+      const monthDate = new Date(year, month - 1); // month is 0-indexed
+      const monthName = monthDate.toLocaleDateString('en-US', { month: 'long' });
+      const monthHeading = createTag('h3', { class: 'blog-archive-month' }, monthName);
+      archiveContainer.appendChild(monthHeading);
+
+      // Create list for blog posts in this month
+      const monthList = createTag('ul', { class: 'blog-archive-list' });
+
+      archiveData[year][month].forEach((post) => {
+        const listItem = createTag('li', { class: 'blog-archive-item' });
+
+        // Create link with date and title
+        const postLink = createTag(
+          'a',
+          {
+            href: post.path,
+            class: 'blog-archive-link',
+          },
+        );
+
+        // Format: "Month Day, Year - Post Title"
+        postLink.textContent = `${post.publicationDate} - ${post.title}`;
+
+        listItem.appendChild(postLink);
+        monthList.appendChild(listItem);
+      });
+
+      archiveContainer.appendChild(monthList);
+    });
+  });
+
+  block.appendChild(archiveContainer);
+}
+
+// Main decorate function for the blog archive block
+export default async function decorate(block) {
+  // Load blog data if it hasn't been loaded yet
+  if (!window.blogindex) {
+    loadBlogData();
+  }
+
+  // Wait a bit for potential data loading, then render
+  setTimeout(() => {
+    renderBlogArchive(block);
+  }, 100);
+
+  // Also listen for the dataset-ready event to render when data is loaded
+  document.addEventListener('dataset-ready', () => {
+    renderBlogArchive(block);
+  });
+}

--- a/blog-archive.html
+++ b/blog-archive.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Blog Archive - AEM.live</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <script>
+    // Mock blog data for demonstration
+    window.blogindex = {
+      data: [
+        {
+          "title": "Getting Started with AEM Sites",
+          "path": "/blog/2023/05/getting-started-aem-sites",
+          "publicationDate": "2023-05-15",
+          "description": "Learn how to get started with AEM Sites for your web projects.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "Jane Doe"
+        },
+        {
+          "title": "Advanced Content Fragments Techniques",
+          "path": "/blog/2023/05/advanced-content-fragments",
+          "publicationDate": "2023-05-10",
+          "description": "Deep dive into advanced content fragment techniques.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "John Smith"
+        },
+        {
+          "title": "AEM as a Cloud Service Best Practices",
+          "path": "/blog/2023/04/aem-cloud-service-best-practices",
+          "publicationDate": "2023-04-22",
+          "description": "Best practices for deploying AEM as a Cloud Service.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "Sam Wilson"
+        },
+        {
+          "title": "Building Responsive Websites with AEM",
+          "path": "/blog/2023/04/responsive-websites-aem",
+          "publicationDate": "2023-04-18",
+          "description": "How to create responsive websites using AEM.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "Alex Johnson"
+        },
+        {
+          "title": "Introduction to HTL in AEM",
+          "path": "/blog/2023/03/introduction-htl-aem",
+          "publicationDate": "2023-03-30",
+          "description": "Getting started with HTML Template Language in AEM.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "Maria Garcia"
+        },
+        {
+          "title": "Workflow Optimization in AEM",
+          "path": "/blog/2023/02/workflow-optimization",
+          "publicationDate": "2023-02-14",
+          "description": "Optimize your AEM workflows for better efficiency.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "David Chen"
+        },
+        {
+          "title": "Component Development Best Practices",
+          "path": "/blog/2023/01/component-development",
+          "publicationDate": "2023-01-25",
+          "description": "Best practices for developing AEM components.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "Sarah Williams"
+        },
+        {
+          "title": "Content Strategy with AEM",
+          "path": "/blog/2022/12/content-strategy",
+          "publicationDate": "2022-12-10",
+          "description": "Develop effective content strategies using AEM.",
+          "image": "/img/default-blog-image.jpg",
+          "author": "Michael Brown"
+        }
+      ],
+      loaded: true
+    };
+    
+    // Simulate window.hlx object
+    window.hlx = {
+      codeBasePath: '.'
+    };
+  </script>
+  <style>
+    /* Basic styling */
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: #fff;
+    }
+    
+    header {
+      background-color: #333;
+      color: white;
+      padding: 1rem;
+    }
+    
+    main {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2rem 1rem;
+    }
+    
+    footer {
+      background-color: #f5f5f5;
+      padding: 1rem;
+      text-align: center;
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>AEM.live Blog Archive</h1>
+  </header>
+  
+  <main>
+    <div class="blog-archive">
+      <div class="section">
+        <div class="blog-archive-wrapper">
+          <div class="blog-archive"></div>
+        </div>
+      </div>
+    </div>
+  </main>
+  
+  <footer>
+    <p>© 2023 AEM.live</p>
+  </footer>
+  
+  <script type="module">
+    // Import our functions
+    import './scripts/scripts.js';
+    import { renderBlogArchive } from './blocks/blog-archive/blog-archive.js';
+    
+    // Wait for DOM to be ready and then render the blog archive
+    document.addEventListener('DOMContentLoaded', () => {
+      const blogArchiveBlock = document.querySelector('.blog-archive');
+      if (blogArchiveBlock) {
+        renderBlogArchive(blogArchiveBlock);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -628,6 +628,56 @@ export function loadBlogData() {
     });
 }
 
+// Helper function to format date as "Month Day, Year"
+function formatDate(date) {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+// Function to get blog archive data grouped by year and month
+export function getBlogArchiveData() {
+  if (!window.blogindex?.data || !window.blogindex.loaded) {
+    return {};
+  }
+
+  // Sort blog entries by publication date in descending order (newest first)
+  const sortedBlogs = [...window.blogindex.data].sort((a, b) => {
+    const dateA = new Date(a.publicationDate);
+    const dateB = new Date(b.publicationDate);
+    return dateB - dateA; // Descending order (newest first)
+  });
+
+  // Group by year and month
+  const archive = {};
+
+  sortedBlogs.forEach((post) => {
+    const pubDate = new Date(post.publicationDate);
+    const year = pubDate.getFullYear();
+    const month = String(pubDate.getMonth() + 1).padStart(2, '0'); // Months are 0-indexed, pad to 2 digits
+
+    if (!archive[year]) {
+      archive[year] = {};
+    }
+
+    if (!archive[year][month]) {
+      archive[year][month] = [];
+    }
+
+    // Add the post data with formatted date
+    archive[year][month].push({
+      title: post.title || post.Title,
+      path: post.path,
+      publicationDate: formatDate(pubDate),
+      author: post.author || 'Unknown Author', // Using default if author not available
+    });
+  });
+
+  return archive;
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -825,7 +875,6 @@ if (window.location.hostname === 'www.hlx.live') {
   const url = `https://www.aem.live${window.location.pathname}${window.location.search}${window.location.hash}`;
   // eslint-disable-next-line no-console
   console.log(`redirecting to ${url}`);
-}
-*/
+} */
 
 loadPage(document);


### PR DESCRIPTION
This PR implements a new blog archive page that groups blog posts by year and month, addressing the growing need as the number of blog posts increases. The implementation includes:
- New getBlogArchiveData() function to group blog posts by year and month
- New blog-archive block with JavaScript and CSS for rendering grouped archive
- Functionality to display posts in chronological order grouped by publication date
- Clean, accessible UI styling

All code passes linting checks. In a Helix project, this would be used by creating a content page that uses the blog-archive block.

**Testing**: This feature can be tested on the feature preview environment at: https://qwen-blog-archive-2--helix-website--adobe.aem.page/ - The blog-archive block functionality will be available for authors to use when creating pages with blog archives.

**Note**: This implementation was created by Qwen (AI model) and should be labeled as such.