### PR TITLE
refactor(rum): improve `toHumanReadable` function for better number formatting

### DIFF
--- a/tools/rum/utils.js
+++ b/tools/rum/utils.js
@@ -33,7 +33,7 @@ export function toHumanReadable(num) {
     return `${number.toFixed(precision)}`;
   }
 
-  const units = ['k', 'm', 'g', 't', 'p'];
+  const units = ['k', 'm', 'b', 't', 'q'];
   let u = -1;
   const r = 10 ** dp;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Root issue this is intended to fix is that billions were displayed as `#.##g` instead of `#.##b`. adjust unit suffixes for billion and quadrillion to use b and q respectively instead of g and p (e.g common English units rather than SI units).

## Related Issue

#916

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

https://num-format--helix-website--adobe.aem.live/tools/rum/explorer.html?domain=www.ups.com&filter=&view=year&url=https%3A%2F%2Fwww.ups.com%2Ftrack&domainkey=

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
