### PR TITLE
chore(deps): update @adobe/rum-distiller to latest pre-release

### DIFF
--- a/tools/oversight/package-lock.json
+++ b/tools/oversight/package-lock.json
@@ -8,13 +8,13 @@
       "name": "@adobe/aem-rum-explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@adobe/rum-distiller": "1.19.0"
+        "@adobe/rum-distiller": "1.19.1-prerelease.4"
       }
     },
     "node_modules/@adobe/rum-distiller": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@adobe/rum-distiller/-/rum-distiller-1.19.0.tgz",
-      "integrity": "sha512-Qb7V7pF8Sy5cd1lqskqlEvmuhMIPek8X+G84Qe236lMgu+8XLM8pk0HJzZdvHAsYGU8M+wmKAccfk6DyIvweng==",
+      "version": "1.19.1-prerelease.4",
+      "resolved": "https://registry.npmjs.org/@adobe/rum-distiller/-/rum-distiller-1.19.1-prerelease.4.tgz",
+      "integrity": "sha512-5k5honGGsQsDG5hIANenAMMJhkaGbio4HjY9urngyEB00hBG+sAx3bpnmcAmuiqf9LOOti+M8DHxv+XR6NDedw==",
       "license": "Apache-2.0"
     }
   }

--- a/tools/oversight/package.json
+++ b/tools/oversight/package.json
@@ -6,6 +6,6 @@
   },
   "type": "module",
   "dependencies": {
-    "@adobe/rum-distiller": "1.19.0"
+    "@adobe/rum-distiller": "1.19.1-prerelease.4"
   }
 }


### PR DESCRIPTION
## Summary
- Updated @adobe/rum-distiller dependency to version 1.19.1-prerelease.4 for performance improvements

## Test URL
https://distiller-perf--helix-website--adobe.aem.live/

🤖 Generated with [Claude Code](https://claude.com/claude-code)