### PR TITLE
chore(oversight): help references for facets/metrics on dashboard

### DIFF
--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -128,7 +128,7 @@
           </list-facet>
           <list-facet facet="userAgent" drilldown="share.html">
             <legend>Device Type and Operating System</legend>
-            <a href="/docs/rum-explorer#device-share" class="help" target="_blank"
+            <a href="/docs/optel-explorer#device-share" class="help" target="_blank"
               title="What devices and operating systems have accessed your site?"></a>
             <dl>
               <dt>desktop</dt>
@@ -163,12 +163,12 @@
           </list-facet>
           <link-facet facet="url" drilldown="list.html" thumbnail="true" highlight="filter">
             <legend>URL</legend>
-            <a href="/docs/rum-explorer#url" class="help" target="_blank"
+            <a href="/docs/optel-explorer#url" class="help" target="_blank"
               title="What different pages make up your site?"></a>
           </link-facet>
           <list-facet facet="checkpoint" drilldown="flow.html" highlight="filter">
             <legend>Checkpoints</legend>
-            <a href="/docs/rum-explorer#checkpoints" class="help" target="_blank"
+            <a href="/docs/optel-explorer#checkpoints" class="help" target="_blank"
               title="What type of activity data is collected?"></a>
             <dl>
               <dt>enter</dt>
@@ -205,33 +205,33 @@
           </list-facet>
           <literal-facet facet="click.source" drilldown="list.html">
             <legend>Click Source (CSS Selector)</legend>
-            <a href="/docs/rum-explorer#facet-click" class="help" target="_blank"
-              title="What page visitors clicked"></a>
+            <a href="/docs/optel-explorer#facet-click" class="help" target="_blank"
+              title="Where the page visitors clicked?"></a>
           </literal-facet>
           <link-facet facet="click.target" drilldown="list.html">
             <legend>Click Target (URL)</legend>
-            <a href="/docs/rum-explorer#facet-click" class="help" target="_blank"
-              title="What page visitors clicked"></a>
+            <a href="/docs/optel-explorer#facet-click" class="help" target="_blank"
+              title="What links the page visitors clicked?"></a>
           </link-facet>
           <literal-facet facet="viewmedia.source" drilldown="list.html">
             <legend>Media Source (CSS Selector)</legend>
-            <a href="/docs/rum-explorer#facet-viewmedia" class="help" target="_blank"
+            <a href="/docs/optel-explorer#facet-viewmedia" class="help" target="_blank"
               title="What image/video visitors have seen?"></a>
           </literal-facet>
           <thumbnail-facet facet="viewmedia.target" drilldown="list.html">
             <legend>Media Target</legend>
-            <a href="/docs/rum-explorer#facet-viewmedia" class="help" target="_blank"
-              title="What image/video visitors have seen?"></a>
+            <a href="/docs/optel-explorer#facet-viewmedia" class="help" target="_blank"
+              title="Preview of the image/video visitors have seen"></a>
           </thumbnail-facet>
           <literal-facet facet="viewblock.source" drilldown="list.html">
             <legend>Block (CSS Selector)</legend>
-            <a href="/docs/rum-explorer#facet-viewblock" class="help" target="_blank"
-              title="What blocks visitors have seen?"></a>
+            <a href="/docs/optel-explorer#facet-viewblock" class="help" target="_blank"
+              title="What blocks page visitors have seen? (dialog for elements which are fixed in the viewport and can't be scrolled away)"></a>
           </literal-facet>
           <link-facet facet="enter.source" drilldown="list.html" thumbnail="true" favicon="true">
             <legend>External Referrer</legend>
-            <a href="/docs/rum-explorer#facet-enter" class="help" target="_blank"
-              title="How the users entered into the site?"></a>
+            <a href="/docs/optel-explorer#facet-enter" class="help" target="_blank"
+              title="How the visitors entered into the site?"></a>
             <dl>
               <dt>(direct)</dt>
               <dd>Direct Entry (or via App)</dd>
@@ -239,6 +239,8 @@
           </link-facet>
           <list-facet facet="enter.target">
             <legend>Enter Target</legend>
+            <a href="/docs/optel-explorer#facet-enter" class="help" target="_blank"
+              title="How did the user open the site page? (directly or probably in a new tab)"></a>
             <dl>
               <dt>visible</dt>
               <dd>Visible</dd>
@@ -248,12 +250,14 @@
           </list-facet>
           <link-facet facet="navigate.source" thumbnail="true" drilldown="list.html">
             <legend>Internal Referrer</legend>
-            <a href="/docs/rum-explorer#facet-navigate" class="help" target="_blank"
+            <a href="/docs/optel-explorer#facet-navigate" class="help" target="_blank"
               title="Internal navigation paths on the site"></a>
           </link-facet>
 
           <list-facet facet="consent.source">
             <legend>Consent Provider</legend>
+            <a href="docs/optel-explorer#facet-consent" class="help" target="_blank" 
+              title="Which consent provider is enabled on the site?"></a>
             <dl>
               <dt>onetrust</dt>
               <dd>OneTrust</dd>
@@ -267,6 +271,8 @@
           </list-facet>
           <list-facet facet="consent.target">
             <legend>Consent Dialog</legend>
+            <a href="docs/optel-explorer#facet-consent" class="help" target="_blank" 
+              title="How does the user interact with the consent window/modal on the site?"></a>
             <dl>
               <dt>show</dt>
               <dd>Dialog Shown</dd>
@@ -281,6 +287,8 @@
 
           <list-facet facet="acquisition.source" drilldown="share.html">
             <legend>Inorganic Traffic Source</legend>
+            <a href="/docs/optel-explorer#facet-acquisition" class="help" target="_blank"
+              title="Which inorganic traffic sources are driving traffic to the site?"></a>
             <dl>
               <dt>paid</dt>
               <dd>All paid traffic</dd>
@@ -345,44 +353,68 @@
 
           <link-facet facet="error.source">
             <legend>Error Source</legend>
+            <a href="/docs/optel-explorer#facet-error" class="help" target="_blank"
+              title="Which files/functions in the code of the site have Javascript errors?"></a>
           </link-facet>
           <literal-facet facet="error.target">
-            <legend>Error Line</legend>
+            <legend>Error Detail</legend>
+            <a href="/docs/optel-explorer#facet-error" class="help" target="_blank"
+              title="Details of the Javascript errors found on the site"></a>
           </literal-facet>
 
           <list-facet facet="loadresource.histogram" sort="asc">
             <legend>Resource Load Time (ms)</legend>
+            <a href="/docs/optel-explorer#facet-loadresource" class="help" target="_blank"
+              title="How long does it take to load the resources (fragments or JSON API endpoints) on the site?"></a>
           </list-facet>
 
           <list-facet facet="loadresource.source">
             <legend>Resource Loaded</legend>
+            <a href="/docs/optel-explorer#facet-loadresource" class="help" target="_blank"
+              title="What fragments and JSON API endpoints are loaded for the site ?"></a>
           </list-facet>
 
           <list-facet facet="missingresource.source">
             <legend>Missing Resource</legend>
+            <a href="/docs/optel-explorer#facet-missingresource" class="help" target="_blank"
+              title="What resources are missing from the site pages ?"></a>
           </list-facet>
 
           <literal-facet facet="cwv-lcp.source">
             <legend>LCP Element (DOM)</legend>
+            <a href="/docs/optel-explorer#facet-lcp" class="help" target="_blank"
+              title="Elements of page that are slowing down page loading"></a>
           </literal-facet>
           <thumbnail-facet facet="cwv-lcp.target">
             <legend>LCP Element (Preview)</legend>
+            <a href="/docs/optel-explorer#facet-lcp" class="help" target="_blank"
+              title="Preview of the elements of page that are slowing down page loading"></a>
           </thumbnail-facet>
           <list-facet facet="language.source">
             <legend>Content Language</legend>
+            <a href="/docs/optel-explorer#facet-language" class="help" target="_blank"
+              title="What content languages are detected on the site?"></a>
           </list-facet>
           <list-facet facet="language.target">
             <legend>Language Preference</legend>
+            <a href="/docs/optel-explorer#facet-language" class="help" target="_blank"
+              title="What language do users select as their preferred language on the site?"></a>
           </list-facet>
           <link-facet facet="redirect.source">
             <legend>Redirect Source</legend>
+            <a href="/docs/optel-explorer#facet-redirect" class="help" target="_blank"
+              title="What links of the site are redirecting?"></a>
           </link-facet>
           <list-facet facet="redirect.target">
             <legend>Redirect Count</legend>
+            <a href="/docs/optel-explorer#facet-redirect" class="help" target="_blank"
+              title="Number of hops it took to reach the final destination page"></a>
           </list-facet>
 
           <list-facet facet="experiment.source">
             <legend>Experiment ID</legend>
+            <a href="/docs/optel-explorer#facet-experiment" class="help" target="_blank"
+              title="What experiments are running on the site?"></a>
           </list-facet>
 
           <list-facet facet="experiment.target">
@@ -390,8 +422,8 @@
           </list-facet>
           <list-facet facet="a11y.source">
             <legend>Accessibility Preferences</legend>
-            <a href="/docs/rum-explorer#facet-a11y" class="help" target="_blank"
-              title="What accessibility preferences and behaviors were detected?"></a>
+            <a href="/docs/optel-explorer#facet-accessibility" class="help" target="_blank"
+              title="What accessibility features are detected on the site?"></a>
             <dl>
               <dt>off</dt>
               <dd>No Accessibility Features Detected</dd>
@@ -407,9 +439,14 @@
           </list-facet>
           <list-facet facet="utm.source">
             <legend>UTM Source</legend>
+            <a href="/docs/optel-explorer#facet-utm" class="help" target="_blank"
+              title="Where the user came from before landing on the site?"></a>
+            
           </list-facet>
           <list-facet facet="utm.target">
             <legend>UTM Target</legend>
+            <a href="/docs/optel-explorer#facet-utm" class="help" target="_blank"
+              title="categorization of the UTM sources driving traffic to the site"></a>
           </list-facet>
         </facet-sidebar>
       </div>

--- a/tools/oversight/flow.html
+++ b/tools/oversight/flow.html
@@ -115,7 +115,7 @@
           <facet-sidebar>
             <list-facet facet="userAgent" drilldown="share.html">
               <legend>Device Type and Operating System</legend>
-              <a href="/docs/rum-explorer#device-share" class="help"
+              <a href="/docs/optel-explorer#device-share" class="help"
               target="_blank" title="What devices and operating systems have accessed your site?"></a>
               <dl>
                 <dt>desktop</dt>
@@ -150,12 +150,12 @@
             </list-facet>
             <link-facet facet="url" drilldown="list.html" thumbnail="true" highlight="filter">
               <legend>URL</legend>
-              <a href="/docs/rum-explorer#url" class="help"
+              <a href="/docs/optel-explorer#url" class="help"
               target="_blank" title="What different pages make up your site?"></a>
             </link-facet>
             <list-facet facet="checkpoint" drilldown="flow.html" highlight="filter">
               <legend>Checkpoints</legend>
-              <a href="/docs/rum-explorer#checkpoints" class="help"
+              <a href="/docs/optel-explorer#checkpoints" class="help"
               target="_blank" title="What type of activity data is collected?"></a>
               <dl>
                 <dt>enter</dt>
@@ -203,7 +203,7 @@
             </list-facet>
             <list-facet facet="clicktarget">
               <legend>Click Target Type</legend>
-              <a href="/docs/rum-explorer#facet-click" class="help"
+              <a href="/docs/optel-explorer#facet-click" class="help"
               target="_blank" title="Where on the page (including links) visitors clicked?"></a>
             </list-facet>
             <list-facet facet="exit">
@@ -214,7 +214,7 @@
             </vitals-facet>
             <thumbnail-facet facet="lcp.target">
               <legend>LCP Image</legend>
-              <a href="/docs/rum-explorer#facet-lcp" class="help"
+              <a href="/docs/optel-explorer#facet-lcp" class="help"
               target="_blank" title="Identify elements of page that are slowing down page loading"></a>
               </thunbnail-facet>
               <literal-facet facet="lcp.source">

--- a/tools/oversight/list.html
+++ b/tools/oversight/list.html
@@ -110,7 +110,7 @@
           <facet-sidebar>
             <list-facet facet="userAgent" drilldown="share.html">
               <legend>Device Type and Operating System</legend>
-              <a href="/docs/rum-explorer#device-share" class="help"
+              <a href="/docs/optel-explorer#device-share" class="help"
               target="_blank" title="What devices and operating systems have accessed your site?"></a>
               <dl>
                 <dt>desktop</dt>
@@ -145,12 +145,12 @@
             </list-facet>
             <link-facet facet="url" drilldown="list.html" thumbnail="true" highlight="filter">
               <legend>URL</legend>
-              <a href="/docs/rum-explorer#url" class="help"
+              <a href="/docs/optel-explorer#url" class="help"
               target="_blank" title="What different pages make up your site?"></a>  
             </link-facet>
             <list-facet facet="checkpoint" drilldown="flow.html" highlight="filter">
               <legend>Checkpoints</legend>
-              <a href="/docs/rum-explorer#checkpoints" class="help"
+              <a href="/docs/optel-explorer#checkpoints" class="help"
               target="_blank" title="What type of activity data is collected?"></a>
               <dl>
                 <dt>enter</dt>
@@ -177,33 +177,33 @@
             </list-facet>
             <literal-facet facet="click.source" drilldown="list.html">
               <legend>Click Source (CSS Selector)</legend>
-              <a href="/docs/rum-explorer#facet-click" class="help"
+              <a href="/docs/optel-explorer#facet-click" class="help"
               target="_blank" title="What page visitors clicked"></a>
             </literal-facet>
             <link-facet facet="click.target" drilldown="list.html">
               <legend>Click Target (URL)</legend>
-              <a href="/docs/rum-explorer#facet-click" class="help"
+              <a href="/docs/optel-explorer#facet-click" class="help"
               target="_blank" title="What page visitors clicked"></a>
             </link-facet>
             <literal-facet facet="viewmedia.source" drilldown="list.html">
               <legend>Media Source (CSS Selector)</legend>
-              <a href="/docs/rum-explorer#facet-viewmedia" class="help"
+              <a href="/docs/optel-explorer#facet-viewmedia" class="help"
               target="_blank" title="What image/video visitors have seen?"></a>
             </literal-facet>
             <thumbnail-facet facet="viewmedia.target" drilldown="list.html">
               <legend>Media Target</legend>
-              <a href="/docs/rum-explorer#facet-viewmedia" class="help"
+              <a href="/docs/optel-explorer#facet-viewmedia" class="help"
               target="_blank" title="What image/video visitors have seen?"></a>
             </thumbnail-facet>
             <literal-facet facet="viewblock.source" drilldown="list.html">
               <legend>Block (CSS Selector)</legend>
-              <a href="/docs/rum-explorer#facet-viewblock" class="help"
-              target="_blank" title="What blocks visitors have seen?"></a>
+              <a href="/docs/optel-explorer#facet-viewblock" class="help"
+              target="_blank" title="What blocks page visitors have seen? (dialog for elements which are fixed in the viewport and can't be scrolled away)"></a>
             </literal-facet>
             <link-facet facet="enter.source" drilldown="list.html" thumbnail="false">
               <legend>External Referrer</legend>
-              <a href="/docs/rum-explorer#facet-enter" class="help"
-              target="_blank" title="How the users entered into the site?"></a>
+              <a href="/docs/optel-explorer#facet-enter" class="help"
+              target="_blank" title="How the visitors entered into the site?"></a>
               <dl>
                 <dt>(direct)</dt>
                 <dd>Direct Entry (or via App)</dd>
@@ -211,12 +211,14 @@
             </link-facet>
             <link-facet facet="navigate.source" thumbnail="true" drilldown="list.html">
               <legend>Internal Referrer</legend>
-              <a href="/docs/rum-explorer#facet-navigate" class="help"
+              <a href="/docs/optel-explorer#facet-navigate" class="help"
               target="_blank" title="Internal navigation paths on the site"></a>
             </link-facet>
 
             <list-facet facet="consent.source">
               <legend>Consent Provider</legend>
+              <a href="docs/optel-explorer#facet-consent" class="help" target="_blank" 
+                title="Which consent provider is enabled on the site?"></a>
               <dl>
                 <dt>onetrust</dt>
                 <dd>OneTrust</dd>
@@ -230,6 +232,8 @@
             </list-facet>
             <list-facet facet="consent.target">
               <legend>Consent Dialog</legend>
+              <a href="docs/optel-explorer#facet-consent" class="help" target="_blank" 
+                title="How does the visitors interact with the consent window/modal on the site?"></a>
               <dl>
                 <dt>show</dt>
                 <dd>Dialog Shown</dd>
@@ -243,16 +247,25 @@
             </list-facet>
             <link-facet facet="error.source">
               <legend>Error Source</legend>
+              <a href="/docs/optel-explorer#facet-error" class="help" target="_blank"
+                title="Which files/functions in the code of the site have Javascript errors?"></a>
             </link-facet>
             <literal-facet facet="error.target">
-              <legend>Error Line</legend>
+              <legend>Error Detail</legend>
+              <a href="/docs/optel-explorer#facet-error" class="help" target="_blank"
+                title="Details of the Javascript errors found on the site"></a>
             </literal-facet>
-            
+
             <list-facet facet="loadresource.histogram" sort="asc">
               <legend>Resource Load Time (ms)</legend>
+              <a href="/docs/optel-explorer#facet-loadresource" class="help" target="_blank"
+                title="How long does it take to load the resources (fragments or JSON API endpoints) on the site?"></a>
             </list-facet>
+
             <list-facet facet="loadresource.source">
               <legend>Resource Loaded</legend>
+              <a href="/docs/optel-explorer#facet-loadresource" class="help" target="_blank"
+                title="What fragments and JSON API endpoints are loaded for the site ?"></a>
             </list-facet>
             <vitals-facet drilldown="cwvperf.html" facet="vitals">
               <legend>Experience Quality</legend>

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -1166,13 +1166,13 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
   display: none;
 }
 
-@media (min-width: 600px) {
+@media (width >= 600px) {
   main .title url-selector input {
     font-size: var(--type-heading-l-size);
   }
 }
 
-@media (min-width: 900px) {
+@media (width >= 900px) {
   main .title {
     flex-wrap: nowrap;
   }
@@ -1240,7 +1240,7 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
 
 /* split mode */
 
-@media (min-width: 1600px) {
+@media (width >= 1600px) {
   #deepmain {
     display: flex;
     gap: 16px;

--- a/tools/oversight/share.html
+++ b/tools/oversight/share.html
@@ -114,7 +114,7 @@
           <facet-sidebar>
             <list-facet facet="userAgent" drilldown="share.html">
               <legend>Device Type and Operating System</legend>
-              <a href="/docs/rum-explorer#device-share" class="help"
+              <a href="/docs/optel-explorer#device-share" class="help"
               target="_blank" title="What devices and operating systems have accessed your site?"></a>
               <dl>
                 <dt>desktop</dt>
@@ -149,12 +149,12 @@
             </list-facet>
             <link-facet facet="url" drilldown="list.html" thumbnail="true" highlight="filter">
               <legend>URL</legend>
-              <a href="/docs/rum-explorer#url" class="help"
+              <a href="/docs/optel-explorer#url" class="help"
               target="_blank" title="What different pages make up your site?"></a>
             </link-facet>
             <list-facet facet="checkpoint" drilldown="flow.html" highlight="filter">
               <legend>Checkpoints</legend>
-              <a href="/docs/rum-explorer#checkpoints" class="help"
+              <a href="/docs/optel-explorer#checkpoints" class="help"
               target="_blank" title="What type of activity data is collected?"></a>
               <dl>
                 <dt>enter</dt>
@@ -181,32 +181,32 @@
             </list-facet>
             <literal-facet facet="click.source" drilldown="list.html">
               <legend>Click Source (CSS Selector)</legend>
-              <a href="/docs/rum-explorer#facet-click" class="help"
+              <a href="/docs/optel-explorer#facet-click" class="help"
               target="_blank" title="What page visitors clicked"></a>
             </literal-facet>
             <link-facet facet="click.target" drilldown="list.html">
               <legend>Click Target (URL)</legend>
-              <a href="/docs/rum-explorer#facet-click" class="help"
+              <a href="/docs/optel-explorer#facet-click" class="help"
               target="_blank" title="What page visitors clicked"></a>
             </link-facet>
             <literal-facet facet="viewmedia.source" drilldown="list.html">
               <legend>Media Source (CSS Selector)</legend>
-              <a href="/docs/rum-explorer#facet-viewmedia" class="help"
+              <a href="/docs/optel-explorer#facet-viewmedia" class="help"
               target="_blank" title="What image/video visitors have seen?"></a>
             </literal-facet>
             <thumbnail-facet facet="viewmedia.target" drilldown="list.html">
               <legend>Media Target</legend>
-              <a href="/docs/rum-explorer#facet-viewmedia" class="help"
+              <a href="/docs/optel-explorer#facet-viewmedia" class="help"
               target="_blank" title="What image/video visitors have seen?"></a>
             </thumbnail-facet>
             <literal-facet facet="viewblock.source" drilldown="list.html">
               <legend>Block (CSS Selector)</legend>
-              <a href="/docs/rum-explorer#facet-viewblock" class="help"
+              <a href="/docs/optel-explorer#facet-viewblock" class="help"
               target="_blank" title="What blocks visitors have seen?"></a>
             </literal-facet>
             <link-facet facet="enter.source" drilldown="list.html" thumbnail="false">
               <legend>External Referrer</legend>
-              <a href="/docs/rum-explorer#facet-enter" class="help"
+              <a href="/docs/optel-explorer#facet-enter" class="help"
               target="_blank" title="How the users entered into the site?"></a>
               <dl>
                 <dt>(direct)</dt>
@@ -215,12 +215,14 @@
             </link-facet>
             <link-facet facet="navigate.source" thumbnail="true" drilldown="list.html">
               <legend>Internal Referrer</legend>
-              <a href="/docs/rum-explorer#facet-navigate" class="help"
+              <a href="/docs/optel-explorer#facet-navigate" class="help"
               target="_blank" title="Internal navigation paths on the site"></a>
             </link-facet>
 
             <list-facet facet="consent.source">
               <legend>Consent Provider</legend>
+              <a href="docs/optel-explorer#facet-consent" class="help" target="_blank" 
+                title="How does the visitors interact with the consent window/modal on the site?"></a>
               <dl>
                 <dt>onetrust</dt>
                 <dd>OneTrust</dd>
@@ -234,6 +236,8 @@
             </list-facet>
             <list-facet facet="consent.target">
               <legend>Consent Dialog</legend>
+              <a href="docs/optel-explorer#facet-consent" class="help" target="_blank" 
+                title="How does the visitors interact with the consent window/modal on the site?"></a>
               <dl>
                 <dt>show</dt>
                 <dd>Dialog Shown</dd>
@@ -246,17 +250,26 @@
               </dl>
             </list-facet>
             <link-facet facet="error.source">
-              <legend>Error Source</legend>
+            <legend>Error Source</legend>
+            <a href="/docs/optel-explorer#facet-error" class="help" target="_blank"
+              title="Which files/functions in the code of the site have Javascript errors?"></a>
             </link-facet>
             <literal-facet facet="error.target">
-              <legend>Error Line</legend>
+              <legend>Error Detail</legend>
+              <a href="/docs/optel-explorer#facet-error" class="help" target="_blank"
+                title="Details of the Javascript errors found on the site"></a>
             </literal-facet>
-            
+
             <list-facet facet="loadresource.histogram" sort="asc">
               <legend>Resource Load Time (ms)</legend>
+              <a href="/docs/optel-explorer#facet-loadresource" class="help" target="_blank"
+                title="How long does it take to load the resources (fragments or JSON API endpoints) on the site?"></a>
             </list-facet>
+
             <list-facet facet="loadresource.source">
               <legend>Resource Loaded</legend>
+              <a href="/docs/optel-explorer#facet-loadresource" class="help" target="_blank"
+                title="What fragments and JSON API endpoints are loaded for the site ?"></a>
             </list-facet>
             <vitals-facet drilldown="cwvperf.html" facet="vitals">
               <legend>Experience Quality</legend>

--- a/tools/oversight/single.html
+++ b/tools/oversight/single.html
@@ -126,7 +126,7 @@
         <facet-sidebar aria-disabled="true">
           <list-facet facet="userAgent">
             <legend>Device Type and Operating System</legend>
-            <a href="/docs/rum-explorer#device-share" class="help"
+            <a href="/docs/optel-explorer#device-share" class="help"
             target="_blank" title="What devices and operating systems have accessed your site?"></a>
             <dl>
               <dt>desktop</dt>
@@ -161,12 +161,12 @@
           </list-facet>
           <link-facet facet="clicktarget">
             <legend>Click Target (URL)</legend>
-            <a href="/docs/rum-explorer#facet-click" class="help"
+            <a href="/docs/optel-explorer#facet-click" class="help"
             target="_blank" title="What page visitors clicked"></a>
           </link-facet>
           <link-facet facet="enter.source" thumbnail="false">
             <legend>External Referrer</legend>
-            <a href="/docs/rum-explorer#facet-enter" class="help"
+            <a href="/docs/optel-explorer#facet-enter" class="help"
             target="_blank" title="How the users entered into the site?"></a>
             <dl>
               <dt>(direct)</dt>

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -105,6 +105,10 @@ export function updateKeyMetrics() {
     pageViewsExtra.setAttribute('precision', 2);
     pageViewsExtra.className = 'extra';
     document.querySelector('#pageviews p').appendChild(pageViewsExtra);
+
+    setTimeout(() => {
+      pageViewsExtra.setAttribute('title', 'Page views per visit');
+    }, 0);
   }
 
   if (dataChunks.totals.visits.sum > 0) {
@@ -117,6 +121,10 @@ export function updateKeyMetrics() {
     visitsExtra.setAttribute('total', 100);
     visitsExtra.className = 'extra';
     document.querySelector('#visits p').appendChild(visitsExtra);
+
+    setTimeout(() => {
+      visitsExtra.setAttribute('title', 'This is the share of traffic that enters your site, and leaves immediately without clicking anywhere on the page.');
+    }, 0);
   } else {
     document.querySelector('#visits p number-format').textContent = 'N/A';
   }
@@ -142,6 +150,10 @@ export function updateKeyMetrics() {
       conversionsExtra.setAttribute('total', 100);
       conversionsExtra.className = 'extra';
       document.querySelector('#conversions p').appendChild(conversionsExtra);
+
+      setTimeout(() => {
+        conversionsExtra.setAttribute('title', 'Percentage of page views where visitors either consumed significant amounts of content or clicked.');
+      }, 0);
     } else if (dataChunks.totals.visits.sum > 0 && !isDefaultConversion) {
       conversionsExtra.textContent = computeConversionRate(
         dataChunks.totals.conversions.sum,
@@ -152,6 +164,10 @@ export function updateKeyMetrics() {
       conversionsExtra.setAttribute('total', 100);
       conversionsExtra.className = 'extra';
       document.querySelector('#conversions p').appendChild(conversionsExtra);
+
+      setTimeout(() => {
+        conversionsExtra.setAttribute('title', 'Percentage of visits that completed a specific goal or action (based on your custom conversion configuration)');
+      }, 0);
     }
   } else {
     document.querySelector('#conversions p number-format').textContent = 'N/A';


### PR DESCRIPTION
## Description
This PR adds better titles to the metrics and extends help feature for all facets on the oversight dashboard

## Related Issue
#929 

## Motivation and Context
This will help teams better understand the meaning of the metrics on the dashboard and point them to the updated documentation references in https://www.aem.live/docs/optel-explorer via help feature on each facet

## How Has This Been Tested?
https://main--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=emigrationbrewing.com&filter=&view=month&=performance&domainkey=open&conversion.checkpoint=click
vs
https://doc-links--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=emigrationbrewing.com&filter=&view=month&=performance&domainkey=open&conversion.checkpoint=click

## Screenshots (if appropriate):
Few examples:
<img width="460" height="166" alt="Screenshot 2025-10-07 at 16 26 49" src="https://github.com/user-attachments/assets/23785245-2582-48f9-9442-54a86ec3db99" />

<img width="429" height="152" alt="Screenshot 2025-10-07 at 16 27 33" src="https://github.com/user-attachments/assets/f7155010-0295-43a6-9763-2c607538f2ce" />



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
