### PR TITLE
fix(oversight): checkpoint facet order in facet sidebar view

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -201,13 +201,6 @@ function updateDataFacets(filterText, params, checkpoint) {
 
   dataChunks.addFacet('type', (bundle) => bundle.hostType);
 
-  dataChunks.addFacet('checkpoint', facets.checkpoint, 'every', 'none');
-
-  dataChunks.addFacet(
-    'conversions',
-    (bundle) => (dataChunks.hasConversion(bundle, conversionSpec) ? 'converted' : 'not-converted'),
-  );
-
   dataChunks.addFacet('userAgent', userAgent, 'some', 'none');
 
   dataChunks.addFacet('rawURL', facets.url, 'some', 'never');
@@ -217,6 +210,13 @@ function updateDataFacets(filterText, params, checkpoint) {
   dataChunks.addClusterFacet('url!', 'rawURL!', {
     count: Math.log10(dataChunks.facets['rawURL!'].length),
   });
+
+  dataChunks.addFacet('checkpoint', facets.checkpoint, 'every', 'none');
+
+  dataChunks.addFacet(
+    'conversions',
+    (bundle) => (dataChunks.hasConversion(bundle, conversionSpec) ? 'converted' : 'not-converted'),
+  );
 
   dataChunks.addFacet('vitals', vitals);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Brings back checkpoint facet after URL facet in dashboard view

## How Has This Been Tested?
https://cp-order--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=emigrationbrewing.com&filter=&view=month&=performance&domainkey=open
vs
https://main--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=emigrationbrewing.com&filter=&view=month&=performance&domainkey=open

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

