### PR TITLE
feat: adding debounce on input fields

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -478,7 +478,7 @@ const io = new IntersectionObserver((entries) => {
     }
 
     let filterInputDebounce;
-    const debounceTimeout = view === 'week' ? 1000 : 0;
+    const debounceTimeout = 1000;
     elems.filterInput.addEventListener('input', () => {
       clearTimeout(filterInputDebounce);
       filterInputDebounce = setTimeout(() => {

--- a/tools/rum/slicer.js
+++ b/tools/rum/slicer.js
@@ -385,14 +385,9 @@ const io = new IntersectionObserver((entries) => {
       loadData(elems.viewSelect.value).then(draw);
     }
 
-    let filterInputDebounce;
-    const debounceTimeout = view === 'week' ? 1000 : 0;
     elems.filterInput.addEventListener('input', () => {
-      clearTimeout(filterInputDebounce);
-      filterInputDebounce = setTimeout(() => {
-        updateState();
-        draw();
-      }, debounceTimeout);
+      updateState();
+      draw();
     });
 
     elems.viewSelect.addEventListener('change', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Ensuring we do not filter on each input in the filter field as it makes text input difficult and blocks the UI. Adding a debounce to prevent that experience.

https://input-field-debounce--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=www.aem.live&filter=&view=month&=conversion&domainkey=open

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
