### PR TITLE
feat: add service-level-objectives block with real-time SLO calculation

### DIFF
--- a/blocks/service-level-objectives/service-level-objectives.css
+++ b/blocks/service-level-objectives/service-level-objectives.css
@@ -1,0 +1,67 @@
+.service-level-objectives {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.service-level-objectives .service {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  padding: 1.5rem;
+  border: 1px solid var(--color-border-gray, #e0e0e0);
+  border-radius: 8px;
+  background-color: var(--color-background-light, #f9f9f9);
+}
+
+.service-level-objectives .service .slo,
+.service-level-objectives .service .uptime {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.service-level-objectives .service h4 {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-secondary, #666);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.service-level-objectives .service p {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text-primary, #000);
+}
+
+.service-level-objectives .service .uptime.ok h4,
+.service-level-objectives .service .uptime.ok p {
+  color: var(--color-success, #2fcc66);
+}
+
+.service-level-objectives .service .uptime.warn h4,
+.service-level-objectives .service .uptime.warn p {
+  color: var(--color-warning, #f5a623);
+}
+
+.service-level-objectives .service .uptime.err h4,
+.service-level-objectives .service .uptime.err p {
+  color: var(--color-error, #e74c3c);
+}
+
+.service-level-objectives .service .uptime p:last-child {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--color-text-secondary, #666);
+}
+
+@media (width <= 600px) {
+  .service-level-objectives .service {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}

--- a/blocks/service-level-objectives/service-level-objectives.js
+++ b/blocks/service-level-objectives/service-level-objectives.js
@@ -1,0 +1,102 @@
+function parseIncidentTimestamp(timestamp) {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function calculateUptime(incidents) {
+  const status = {};
+  [
+    ['delivery', 0.9999],
+    ['publishing', 0.999],
+  ].forEach(([service, sla]) => {
+    status[service] = {
+      sla,
+      uptime: 1,
+      numIncidents: 0,
+    };
+  });
+
+  const ninetyDaysMins = 90 * 24 * 60;
+  const ninetyDaysMillies = ninetyDaysMins * 60 * 1000;
+
+  incidents
+    .map((incident) => ({
+      startTime: parseIncidentTimestamp(incident.startTime),
+      endTime: parseIncidentTimestamp(incident.endTime),
+      impactedService: incident.impactedService,
+      errorRate: parseFloat(incident.errorRate) || 0,
+    }))
+    .filter(({
+      startTime, endTime, impactedService, errorRate,
+    }) => startTime && endTime && impactedService && errorRate)
+    .filter(({ startTime }) => startTime > new Date(Date.now() - ninetyDaysMillies))
+    .forEach(({
+      startTime, endTime, impactedService, errorRate,
+    }) => {
+      const disruptionMins = Math.round((endTime.getTime() - startTime.getTime()) / 60000);
+      const downtimeMins = disruptionMins * errorRate;
+      const uptimeMins = ninetyDaysMins - downtimeMins;
+      const uptime = uptimeMins / ninetyDaysMins;
+
+      status[impactedService].uptime = uptime;
+      status[impactedService].numIncidents += 1;
+    });
+
+  Object.entries(status).forEach(([, serviceStatus]) => {
+    // eslint-disable-next-line no-param-reassign
+    serviceStatus.uptimePercentage = `${(serviceStatus.uptime * 100)}`.slice(0, 6);
+  });
+
+  return status;
+}
+
+export default async function decorate(block) {
+  try {
+    const response = await fetch('https://www.aemstatus.net/incidents/index.json');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch incidents: ${response.status}`);
+    }
+
+    const incidents = await response.json();
+    const status = calculateUptime(incidents);
+
+    block.innerHTML = '';
+
+    Object.entries(status).forEach(([service, serviceStatus]) => {
+      const serviceName = service.charAt(0).toUpperCase() + service.slice(1);
+      const serviceDiv = document.createElement('div');
+      serviceDiv.className = `service ${service}`;
+
+      const sloDiv = document.createElement('div');
+      sloDiv.className = 'slo';
+      sloDiv.innerHTML = `
+        <h4>${serviceName} Service SLO</h4>
+        <p>${(serviceStatus.sla * 100).toFixed(2)}%</p>
+      `;
+
+      const uptimeDiv = document.createElement('div');
+      uptimeDiv.className = 'uptime';
+
+      let uptimeClass = 'ok';
+      if (serviceStatus.uptime < serviceStatus.sla) {
+        uptimeClass = 'err';
+      } else if (serviceStatus.uptime < serviceStatus.sla * 1.001) {
+        uptimeClass = 'warn';
+      }
+      uptimeDiv.classList.add(uptimeClass);
+
+      uptimeDiv.innerHTML = `
+        <h4>90-Day Uptime: ${serviceStatus.uptimePercentage}%</h4>
+        <p>${serviceStatus.numIncidents} incident${serviceStatus.numIncidents === 1 ? '' : 's'}</p>
+      `;
+
+      serviceDiv.appendChild(sloDiv);
+      serviceDiv.appendChild(uptimeDiv);
+      block.appendChild(serviceDiv);
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error loading service level objectives:', error);
+    block.innerHTML = '<p>Unable to load current service statistics. Please check <a href="https://www.aemstatus.net">aemstatus.net</a> for the latest information.</p>';
+  }
+}


### PR DESCRIPTION
This PR adds a new service-level-objectives block that dynamically calculates and displays the actual service level objectives based on incident data from the aemstatus.net API.

## Features
- Fetches real-time incidents from https://www.aemstatus.net/incidents/index.json
- Implements the same SLO calculation algorithm as adobe/aem-status
- Displays both SLO targets (99.99% for delivery, 99.9% for publishing) and actual 90-day uptime
- Shows incident counts for each service
- Color-coded status indicators (green/yellow/red) based on performance vs SLO
- Responsive design following project standards

## Testing
You can test the block at: https://service-level-objectives-block--helix-website--adobe.aem.page/docs/operations

The block replaces the static SLO display with dynamic, up-to-date service level calculations.

## Implementation Details
The block uses the exact algorithm from adobe/aem-status:
1. Filters incidents from the last 90 days
2. Calculates disruption time weighted by error rate
3. Computes uptime percentage
4. Compares against SLO targets (99.99% delivery, 99.9% publishing)

All linting passes and the code follows AEM Edge Delivery best practices.