### PR TITLE
fix: resolve flaky publication-time test timing race condition

### DIFF
--- a/tests/blocks/publication-time/publication-time.test.js
+++ b/tests/blocks/publication-time/publication-time.test.js
@@ -11,11 +11,18 @@ document.body.innerHTML = mock;
 describe('Publication time block', async () => {
   it('has a relative-time element', async () => {
     const block = document.querySelector('.block');
-    decorate(block);
-    const rt = document.querySelector('relative-time');
+    // Capture lastModified BEFORE calling decorate to avoid timing race condition
     const lastMod = new Date(document.lastModified);
     const shortDate = lastMod.toLocaleDateString();
-    expect(rt.getAttribute('datetime')).to.equal(lastMod.toISOString());
+    decorate(block);
+    const rt = document.querySelector('relative-time');
+    const rtDatetime = rt.getAttribute('datetime');
+
+    // Allow for small time differences (±2 seconds) to handle timing edge cases
+    const rtDate = new Date(rtDatetime);
+    const timeDiff = Math.abs(rtDate.getTime() - lastMod.getTime());
+    expect(timeDiff).to.be.at.most(2000, `Time difference was ${timeDiff}ms`);
+
     expect(rt.textContent).to.equal(shortDate);
     expect(block.textContent).to.equal(`prefix for relative time ${shortDate}`);
   });


### PR DESCRIPTION
## Summary

Fixes #965 - Resolves the flaky publication-time test that was failing intermittently due to a timing race condition.

## Changes

- Moved `document.lastModified` capture to BEFORE calling `decorate(block)` to minimize timing differences
- Changed assertion from exact timestamp equality to allow ±2 seconds tolerance for edge cases
- Added descriptive error message to time difference assertion

## Root Cause

The test was creating a `Date` object from `document.lastModified` AFTER calling `decorate()`, but the block's decorate function also reads `document.lastModified` internally. When these two reads happened on different sides of a second boundary, the timestamps would differ by 1 second, causing the test to fail.

## Test Plan

- ✅ Test now passes consistently: `npm test -- --files tests/blocks/publication-time/publication-time.test.js`
- ✅ All linting checks pass: `npm run lint`

## Test URL

**Note:** This is a test-only change with no runtime code modifications. The fix only affects `tests/blocks/publication-time/publication-time.test.js` and does not change any visual behavior on live pages.

Since there are no visual changes, there is no URL to preview. The effectiveness of this fix is demonstrated by the test passing in CI, which you can verify once the PR checks complete.

For reference, the publication-time block is used on pages like:
- https://fix-flaky-publication-time-test--helix-website--adobe.aem.live/ (any page with publication time)

But the visual output remains unchanged - only the test reliability is improved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)