### PR TITLE
fix: preserve aspect ratio for CDN logos in questionnaire block

### DIFF
--- a/blocks/questionnaire/questionnaire.css
+++ b/blocks/questionnaire/questionnaire.css
@@ -196,6 +196,7 @@
 
 .questionnaire details .has-logo .logo img {
   height: 100px;
+  width: auto;
 }
 
 @media (width >= 1200px) {


### PR DESCRIPTION
Fixes #919

The CDN logos in the questionnaire block were being squished because the CSS applied a fixed height of 100px without setting `width: auto`, causing the images to lose their original aspect ratio.

## Changes
- Added `width: auto` to `.questionnaire details .has-logo .logo img` to preserve the aspect ratio

## Testing
- ✅ Linting passes
- Demo URL: https://amp-2--helix-website--adobe.aem.live/docs/cdn-guide