### PR TITLE
Fix image aspect ratio in questionnaire block CDN selector

### DIFF
--- a/blocks/questionnaire/questionnaire.css
+++ b/blocks/questionnaire/questionnaire.css
@@ -195,7 +195,9 @@
 }
 
 .questionnaire details .has-logo .logo img {
-  height: 100px;
+  height: auto;
+  max-height: 100px;
+  object-fit: contain;
 }
 
 @media (width >= 1200px) {
@@ -225,7 +227,8 @@
     position: absolute;
     top: 0;
     left: 0;
-    height: max-content;
+    height: auto;
     max-height: 100%;
+    object-fit: contain;
   }
 }


### PR DESCRIPTION
## Summary
- Fixed image aspect ratio distortion in the questionnaire block CDN selector
- Changed fixed height (100px) to auto with max-height constraint  
- Added object-fit: contain to preserve original aspect ratios
- Applied fix to both mobile and desktop logo image styling

## Testing
- Verified CSS changes follow project conventions
- All linting checks pass
- Fixes issue #919 where CDN logos appeared squished

The images now maintain their original aspect ratios while still being constrained to appropriate maximum heights.