### PR TITLE
fix: maintain aspect ratio for CDN logos in questionnaire block

### DIFF
--- a/blocks/questionnaire/questionnaire.css
+++ b/blocks/questionnaire/questionnaire.css
@@ -196,6 +196,8 @@
 
 .questionnaire details .has-logo .logo img {
   height: 100px;
+  width: auto;
+  object-fit: contain;
 }
 
 @media (width >= 1200px) {
@@ -225,7 +227,9 @@
     position: absolute;
     top: 0;
     left: 0;
-    height: max-content;
+    height: auto;
     max-height: 100%;
+    max-width: 100%;
+    object-fit: contain;
   }
 }


### PR DESCRIPTION
## Summary
Fixed the squished CDN logos on the CDN guide page as reported in #919. The logos now maintain their original aspect ratio instead of being distorted.

## Changes Made
- Added `width: auto` to logo images to prevent horizontal squishing
- Added `max-width: 100%` to prevent overflow on desktop layouts  
- Changed `height` from `max-content` to `auto` for proper scaling
- Added `object-fit: contain` to maintain proper aspect ratio

## Test Plan
- [x] Tested locally with AEM dev server at http://localhost:3000/docs/cdn-guide
- [x] Verified logos display with correct aspect ratio in both mobile and desktop layouts
- [x] All linting checks pass (eslint + stylelint)

## Preview URL
https://fix-questionnaire-logo-aspect-ratio--helix-website--adobe.aem.live/docs/cdn-guide

Fixes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)