### PR TITLE
fix(questionnaire): preserve aspect ratio for CDN logos

### DIFF
--- a/blocks/questionnaire/questionnaire.css
+++ b/blocks/questionnaire/questionnaire.css
@@ -196,6 +196,9 @@
 
 .questionnaire details .has-logo .logo img {
   height: 100px;
+  width: auto;
+  max-width: 100%;
+  object-fit: contain;
 }
 
 @media (width >= 1200px) {
@@ -227,5 +230,7 @@
     left: 0;
     height: max-content;
     max-height: 100%;
+    width: 100%;
+    object-fit: contain;
   }
 }


### PR DESCRIPTION
Fixes issue #919 - Image aspect ratio on CDN Selector is wrong

**Problem**: The CDN logos on the CDN guide page were squished and not maintaining their original aspect ratios.

**Root Cause**: The questionnaire block's CSS was constraining logo images to a fixed height without proper width constraints and object-fit settings. This caused the logos to be distorted when the images had forced aspect ratios from the backend (width="1200" height="600" attributes).

**Solution**: 
- Added  to logo images in both mobile and desktop layouts
- Set proper width constraints (, )
- Applied to both the mobile view (.has-logo .logo img) and desktop view (responsive grid layout)

**Changes Made**:
- Modified  to preserve aspect ratio for logo images
- The fix affects the CDN guide questionnaire and any other questionnaire blocks with logos

**Testing**:
- Verified locally on http://localhost:3529/docs/cdn-guide
- Tested with various CDN logos (Fastly, Cloudflare, Akamai, etc.)
- All logos now display with proper aspect ratios without squishing

Fixes: #919

Preview: https://droid-2--helix-website--adobe.aem.live/docs/cdn-guide