### PR TITLE
feat: add reading progress bar and back-to-top button for long-form pages

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -777,6 +777,61 @@ async function loadLazy(doc) {
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
 
+  // Initialize reading progress bar and back-to-top button
+  const initReadingProgressAndBackToTop = () => {
+    // Create reading progress bar
+    const progressContainer = createTag('div', { class: 'reading-progress' });
+    const progressBar = createTag('div', { class: 'reading-progress-bar' });
+    progressContainer.append(progressBar);
+    document.body.prepend(progressContainer);
+
+    // Create back-to-top button
+    const backToTopBtn = createTag('button', {
+      class: 'back-to-top',
+      'aria-label': 'Back to top',
+      type: 'button',
+    });
+    document.body.append(backToTopBtn);
+
+    // Update progress bar on scroll
+    const updateReadingProgress = () => {
+      const windowHeight = window.innerHeight;
+      const documentHeight = document.documentElement.scrollHeight - windowHeight;
+      const scrollTop = window.scrollY;
+      const progress = documentHeight > 0 ? (scrollTop / documentHeight) * 100 : 0;
+      progressBar.style.width = `${progress}%`;
+
+      // Show/hide back-to-top button after scrolling past first screen
+      if (scrollTop > windowHeight) {
+        backToTopBtn.classList.add('visible');
+      } else {
+        backToTopBtn.classList.remove('visible');
+      }
+    };
+
+    // Handle back-to-top button click
+    backToTopBtn.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+
+    // Throttle scroll events for better performance
+    let ticking = false;
+    window.addEventListener('scroll', () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          updateReadingProgress();
+          ticking = false;
+        });
+        ticking = true;
+      }
+    });
+
+    // Initialize on page load
+    updateReadingProgress();
+  };
+
+  initReadingProgressAndBackToTop();
+
   if (getMetadata('supressframe')) {
     doc.querySelector('header').remove();
     doc.querySelector('footer').remove();

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -71,3 +71,87 @@
   font-style: normal;
   font-weight: 900;
 }
+
+/* Reading progress bar */
+.reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background-color: var(--bg-color-lightgrey);
+  z-index: 9997;
+  pointer-events: none;
+}
+
+.reading-progress-bar {
+  height: 100%;
+  background-color: var(--spectrum-blue);
+  width: 0;
+  transition: width 0.1s ease-out;
+}
+
+/* Back to top button */
+.back-to-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 48px;
+  height: 48px;
+  background-color: var(--spectrum-blue);
+  color: var(--color-white);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease, background-color 0.2s ease, transform 0.2s ease;
+  z-index: 9997;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.back-to-top:hover {
+  background-color: var(--dark-spectrum-blue);
+  transform: translateY(-2px);
+}
+
+.back-to-top:active {
+  transform: translateY(0);
+}
+
+.back-to-top:focus-visible {
+  outline: 2px solid var(--spectrum-blue);
+  outline-offset: 2px;
+}
+
+.back-to-top::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-top: 2px solid currentcolor;
+  border-right: 2px solid currentcolor;
+  transform: rotate(-45deg);
+  margin-top: 4px;
+}
+
+@media (width >= 600px) {
+  .back-to-top {
+    bottom: 32px;
+    right: 32px;
+    width: 56px;
+    height: 56px;
+  }
+
+  .back-to-top::before {
+    width: 14px;
+    height: 14px;
+  }
+}


### PR DESCRIPTION
## Summary

Adds two UX enhancements for improved navigation on long-form content pages:

- **Reading progress bar**: A thin (3px) bar at the top of the page that fills based on scroll percentage
- **Back-to-top button**: A floating button (bottom-right) that appears after scrolling past the first screen and smoothly scrolls back to top when clicked

## Implementation Details

- Added CSS styling to `styles/lazy-styles.css` using existing design tokens
- Added JavaScript initialization in `scripts/scripts.js` during the lazy loading phase
- Features are keyboard accessible (back-to-top button has proper ARIA label and focus styling)
- Performance-optimized with scroll throttling using `requestAnimationFrame`
- Responsive design with different button sizes for mobile/desktop
- Both elements positioned with z-index 9997 (below navigation)

## Test Plan

- [x] Linting passed (`npm run lint`)
- [x] Reading progress bar fills correctly as page scrolls
- [x] Back-to-top button appears after scrolling past first viewport
- [x] Back-to-top button smoothly scrolls to top on click
- [x] Keyboard navigation works correctly
- [x] Styles align with existing design system
- [x] Features work on mobile and desktop viewports

## Preview Link

Test the features on any page:
- Home page: https://reading-progress-and-back-to-top--helix-website--adobe.aem.page/
- Docs page: https://reading-progress-and-back-to-top--helix-website--adobe.aem.page/docs/

## Tool Information

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- Model: Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)
- Agent: Claude Code CLI

Co-Authored-By: Claude <noreply@anthropic.com>