### PR TITLE
Add reading progress + back-to-top affordances

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -277,6 +277,115 @@ body.appear {
   display: unset;
 }
 
+.reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: rgb(104 112 236 / 15%);
+  z-index: 10000;
+  pointer-events: none;
+  overflow: hidden;
+  opacity: 1;
+  transition: opacity 0.2s var(--cubic-bezier-1);
+}
+
+.reading-progress.is-hidden {
+  opacity: 0;
+}
+
+.reading-progress-fill {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    var(--color-accent-blue, var(--spectrum-blue)) 0%,
+    var(--dark-spectrum-blue)
+  );
+  transform-origin: left center;
+  transform: scaleX(0);
+  transition: transform 0.18s var(--cubic-bezier-1);
+}
+
+.back-to-top-button {
+  position: fixed;
+  bottom: var(--spacing-s);
+  right: var(--spacing-s);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xxs);
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--color-white);
+  border: 1px solid rgb(104 112 236 / 35%);
+  color: var(--color-font-grey);
+  font-size: var(--type-body-s-size);
+  font-weight: 600;
+  box-shadow: 0 18px 32px rgb(0 0 0 / 15%);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition: opacity 0.25s var(--cubic-bezier-2),
+    transform 0.25s var(--cubic-bezier-2),
+    box-shadow 0.25s var(--cubic-bezier-2);
+  z-index: 10001;
+}
+
+.back-to-top-button.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.back-to-top-button:focus-visible {
+  outline: 2px solid var(--color-accent-blue, var(--spectrum-blue));
+  outline-offset: 4px;
+}
+
+.back-to-top-button-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--color-accent-blue, var(--spectrum-blue));
+  color: var(--color-white);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 30%);
+}
+
+.back-to-top-button-icon::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-left: 2px solid currentcolor;
+  border-top: 2px solid currentcolor;
+  transform: rotate(45deg);
+  margin-top: 2px;
+}
+
+.back-to-top-button-label {
+  white-space: nowrap;
+}
+
+@media screen and (width <= 600px) {
+  .back-to-top-button {
+    bottom: var(--spacing-xs);
+    right: var(--spacing-xs);
+    padding: 8px 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reading-progress-fill,
+  .reading-progress,
+  .back-to-top-button {
+    transition: none;
+  }
+}
+
 /* block style for container width, max-width */
 .block.contained,
 .section.content > div,


### PR DESCRIPTION
## Summary
- add a thin, token-aligned reading progress indicator for guides/docs/blog templates
- introduce an accessible floating back-to-top action that appears after scrolling the first viewport
- wire both enhancements in scripts.js with subtle global styling that respects motion preferences

## Testing
- npm run lint
- Preview: https://codex-2--helix-website--adobe.aem.page/developer/tutorial

Tool/Model: Codex (GPT-5)
