### PR TITLE
feat: add copy button to code blocks

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -171,11 +171,55 @@ export function addAnchorLink(elem) {
   elem.append(link);
 }
 
+function addCopyButtonToCodeBlock(pre) {
+  const button = createTag('button', {
+    class: 'code-copy-button',
+    type: 'button',
+    'aria-label': 'Copy code to clipboard',
+  });
+
+  const copyIcon = createTag('span', { class: 'copy-icon', 'aria-hidden': 'true' }, '📋');
+  const checkIcon = createTag('span', { class: 'check-icon', 'aria-hidden': 'true' }, '✓');
+  button.append(copyIcon, checkIcon);
+
+  button.addEventListener('click', async () => {
+    const code = pre.querySelector('code');
+    if (!code) return;
+
+    try {
+      await navigator.clipboard.writeText(code.textContent);
+      button.classList.add('copied');
+      button.setAttribute('aria-label', 'Code copied to clipboard');
+
+      setTimeout(() => {
+        button.classList.remove('copied');
+        button.setAttribute('aria-label', 'Copy code to clipboard');
+      }, 2000);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to copy code:', err);
+    }
+  });
+
+  pre.style.position = 'relative';
+  pre.append(button);
+}
+
+export function decorateCodeBlocks() {
+  const codeBlocks = document.querySelectorAll('pre:has(code)');
+  codeBlocks.forEach((pre) => {
+    if (!pre.querySelector('.code-copy-button')) {
+      addCopyButtonToCodeBlock(pre);
+    }
+  });
+}
+
 export function decorateHeadings(main) {
   if (!document.body.classList.contains('docs-template')) return;
   main.querySelectorAll('h2, h3, h4, h5, h6').forEach((h) => {
     addAnchorLink(h);
   });
+  decorateCodeBlocks();
 }
 
 export function addMessageBoxOnGuideTemplate(main) {
@@ -354,6 +398,7 @@ export function decorateGuideTemplate(main) {
   decorateGuideTemplateHeadings(main);
   decorateGuideTemplateHero(main);
   decorateGuideTemplateLinks(main);
+  decorateCodeBlocks();
 }
 
 export function decoratesSkillTemplate(main) {
@@ -361,6 +406,7 @@ export function decoratesSkillTemplate(main) {
   decorateGuideTemplateHeadings(main);
   decorateGuideTemplateHero(main);
   decorateGuideTemplateLinks(main);
+  decorateCodeBlocks();
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -511,6 +511,58 @@ code:not(pre > code) {
   }
 }
 
+/* Code copy button */
+.code-copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 6px 10px;
+  background-color: rgb(255 255 255 / 10%);
+  border: 1px solid rgb(255 255 255 / 20%);
+  border-radius: 4px;
+  color: #fff;
+  font-size: 14px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+  z-index: 1;
+}
+
+.code-copy-button:hover {
+  background-color: rgb(255 255 255 / 20%);
+}
+
+.code-copy-button:focus {
+  opacity: 1;
+  outline: 2px solid var(--color-accent-highlight-yellow);
+  outline-offset: 2px;
+}
+
+.code-copy-button:active {
+  background-color: rgb(255 255 255 / 30%);
+}
+
+pre:hover .code-copy-button,
+pre:focus-within .code-copy-button {
+  opacity: 1;
+}
+
+.code-copy-button .check-icon {
+  display: none;
+}
+
+.code-copy-button.copied {
+  background-color: rgb(76 175 80 / 30%);
+}
+
+.code-copy-button.copied .copy-icon {
+  display: none;
+}
+
+.code-copy-button.copied .check-icon {
+  display: inline;
+}
+
 /* Icon on button */
 
 em a img,


### PR DESCRIPTION
## Summary
Adds a small copy button to all fenced code blocks across docs pages.

## Changes
- Added `decorateCodeBlocks()` function that adds copy buttons to all code blocks
- Copy button appears on hover or keyboard focus
- Shows visual feedback (checkmark) when code is copied
- Fully keyboard accessible with proper ARIA labels
- Integrated seamlessly with existing highlight.js implementation

## Accessibility
- Button has proper `aria-label` attributes
- Keyboard navigable with visible focus states
- Updates ARIA label on copy success
- Screen reader friendly with `aria-hidden` on decorative icons

## Preview URL
https://code-copy-button--helix-website--adobe.aem.page/

## Testing
- Tested on docs pages with code blocks
- Verified keyboard navigation works
- Confirmed screen reader compatibility
- Linting passes

---
**Generated by**: Claude Sonnet 4.5 (Anthropic AI)
**Tool**: Factory Droid