### PR TITLE
feat: add reading progress bar and back to top button

### DIFF
--- a/scripts/reading-progress.js
+++ b/scripts/reading-progress.js
@@ -1,0 +1,50 @@
+function handleReadingProgress() {
+  const progressBar = document.querySelector('.progress-bar');
+  if (!progressBar) {
+    return;
+  }
+
+  const totalHeight = document.body.scrollHeight - window.innerHeight;
+  const progress = (window.pageYOffset / totalHeight) * 100;
+  progressBar.style.width = `${progress}%`;
+}
+
+function handleBackToTopButton() {
+  const backToTopButton = document.getElementById('back-to-top');
+  if (!backToTopButton) {
+    return;
+  }
+
+  if (window.pageYOffset > window.innerHeight) {
+    backToTopButton.style.display = 'block';
+  } else {
+    backToTopButton.style.display = 'none';
+  }
+}
+
+function scrollToTop() {
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+function initReadingProgress() {
+  const progressContainer = document.createElement('div');
+  progressContainer.className = 'progress-container';
+  const progressBar = document.createElement('div');
+  progressBar.className = 'progress-bar';
+  progressContainer.append(progressBar);
+  document.body.prepend(progressContainer);
+
+  const backToTopButton = document.createElement('button');
+  backToTopButton.id = 'back-to-top';
+  backToTopButton.textContent = '↑';
+  backToTopButton.setAttribute('aria-label', 'Back to top');
+  backToTopButton.addEventListener('click', scrollToTop);
+  document.body.append(backToTopButton);
+
+  window.addEventListener('scroll', () => {
+    handleReadingProgress();
+    handleBackToTopButton();
+  });
+}
+
+initReadingProgress();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -645,6 +645,10 @@ export function decorateMain(main) {
   decorateBlocks(main);
   decorateTitleSection(main);
   decorateSVGs(main);
+
+  if (document.body.scrollHeight > window.innerHeight * 2) {
+    document.body.classList.add('long-form');
+  }
 }
 
 function prepareSideNav(main) {
@@ -776,6 +780,11 @@ async function loadLazy(doc) {
   loadFooter(doc.querySelector('footer'));
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
+
+  if (document.body.classList.contains('long-form')) {
+    loadCSS(`${window.hlx.codeBasePath}/styles/reading-progress.css`);
+    await loadScript(`${window.hlx.codeBasePath}/scripts/reading-progress.js`);
+  }
 
   if (getMetadata('supressframe')) {
     doc.querySelector('header').remove();

--- a/styles/reading-progress.css
+++ b/styles/reading-progress.css
@@ -1,0 +1,39 @@
+
+.progress-container {
+  width: 100%;
+  height: 8px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  background: transparent;
+}
+
+.progress-bar {
+  height: 8px;
+  background: var(--highlight-background-color, #ff8000);
+  width: 0%;
+}
+
+#back-to-top {
+  display: none;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 99;
+  border: none;
+  outline: none;
+  background-color: var(--highlight-background-color, #ff8000);
+  color: white;
+  cursor: pointer;
+  padding: 15px;
+  border-radius: 10px;
+  font-size: 18px;
+  opacity: 0.7;
+  transition: opacity 0.3s;
+}
+
+#back-to-top:hover,
+#back-to-top:focus {
+  opacity: 1;
+}


### PR DESCRIPTION
Adds a reading progress bar at the top of the page and a 'Back to top' button on long-form pages. The feature is conditionally loaded for pages with a scroll height greater than twice the viewport height.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
