### PR TITLE
feat(blog-archive): create blog archive block with year/month grouping

### DIFF
--- a/blocks/blog-archive/blog-archive.css
+++ b/blocks/blog-archive/blog-archive.css
@@ -1,0 +1,162 @@
+.blog-archive {
+  display: none;
+}
+
+.blog-archive[data-rendered='true'] {
+  display: block;
+}
+
+.blog-archive-section {
+  margin-bottom: var(--spacing-xxl, 60px);
+}
+
+.blog-archive-header {
+  margin-bottom: var(--spacing-l, 30px);
+  border-bottom: 2px solid var(--color-border, #e0e0e0);
+  padding-bottom: var(--spacing-m, 20px);
+}
+
+.archive-period {
+  font-size: var(--type-heading-l-size, 28px);
+  line-height: var(--type-heading-l-lh, 1.2);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  margin: 0;
+  color: var(--text-primary, #000);
+}
+
+.blog-archive-posts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-l, 30px);
+}
+
+.card-link {
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-link:hover {
+  transform: translateY(-4px);
+}
+
+.blog-post-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: var(--card-border-radius-s, 8px);
+  overflow: hidden;
+  transition: box-shadow 0.2s ease;
+}
+
+.card-link:hover .blog-post-card {
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+}
+
+.card-content {
+  flex: 1;
+  padding: var(--spacing-l, 30px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s, 10px);
+}
+
+.post-title {
+  font-size: var(--type-heading-m-size, 20px);
+  line-height: var(--type-heading-m-lh, 1.3);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--text-primary, #000);
+  overflow-wrap: break-word;
+}
+
+.post-date {
+  font-size: var(--type-body-xs-size, 12px);
+  line-height: var(--type-body-xs-lh, 1.5);
+  color: var(--text-secondary, #666);
+  margin: 0;
+}
+
+.post-author {
+  font-size: var(--type-body-xs-size, 12px);
+  line-height: var(--type-body-xs-lh, 1.5);
+  color: var(--text-secondary, #666);
+  margin: 0;
+  font-weight: 500;
+}
+
+.post-excerpt {
+  font-size: var(--type-body-s-size, 14px);
+  line-height: var(--type-body-s-lh, 1.6);
+  color: var(--text-primary, #000);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-image {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--bg-image, #f0f0f0);
+}
+
+.card-image picture,
+.card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+@media (width >= 768px) {
+  .blog-post-card {
+    flex-direction: row;
+  }
+
+  .card-image {
+    width: 35%;
+    aspect-ratio: auto;
+    min-height: 250px;
+    order: 2;
+    flex-shrink: 0;
+  }
+
+  .card-content {
+    width: 65%;
+    order: 1;
+  }
+}
+
+@media (width >= 1200px) {
+  .blog-archive-posts {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .blog-post-card {
+    flex-direction: column;
+  }
+
+  .card-image {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    order: 0;
+  }
+
+  .card-content {
+    width: 100%;
+    order: 0;
+  }
+
+  .archive-period {
+    font-size: var(--type-heading-xl-size, 32px);
+    line-height: var(--type-heading-xl-lh, 1.1);
+  }
+}

--- a/blocks/blog-archive/blog-archive.js
+++ b/blocks/blog-archive/blog-archive.js
@@ -1,0 +1,185 @@
+import { createTag, loadBlogData } from '../../scripts/scripts.js';
+import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
+
+async function fetchBlogMetadata(url) {
+  try {
+    const response = await fetch(url);
+    const responseText = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(responseText, 'text/html');
+
+    const getMetaContent = (selector) => {
+      const el = doc.querySelector(selector);
+      return el ? el.getAttribute('content') : '';
+    };
+
+    const author = getMetaContent('meta[name="author"]');
+
+    // Extract excerpt - try to get 1-2 sentences from the body
+    const bodyContent = doc.querySelector('body main');
+    let excerpt = '';
+    if (bodyContent) {
+      const bodyText = bodyContent.textContent;
+      const sentences = bodyText.match(/[^.!?]+[.!?]+/g) || [];
+      excerpt = (sentences.slice(0, 2).join(' ').trim()).substring(0, 200);
+    }
+
+    return { author, excerpt };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Error fetching blog metadata:', error);
+    return { author: '', excerpt: '' };
+  }
+}
+
+function groupPostsByYearMonth(posts) {
+  const groups = {};
+
+  posts.forEach((post) => {
+    const date = new Date(post.publicationDate);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const key = `${year}-${month}`;
+
+    if (!groups[key]) {
+      groups[key] = {
+        year,
+        month,
+        monthName: date.toLocaleString('default', { month: 'long' }),
+        posts: [],
+      };
+    }
+    groups[key].posts.push(post);
+  });
+
+  return Object.entries(groups)
+    .sort((a, b) => {
+      const [keyA] = a;
+      const [keyB] = b;
+      return keyB.localeCompare(keyA);
+    })
+    .map(([, value]) => value);
+}
+
+function createPostCard(post, metadata) {
+  const postCard = createTag('article', { class: 'blog-post-card' });
+
+  const cardContent = createTag('div', { class: 'card-content' });
+
+  // Title
+  const title = createTag('h3', { class: 'post-title' }, post.title);
+  cardContent.appendChild(title);
+
+  // Date
+  const date = new Date(post.publicationDate);
+  const dateStr = date.toLocaleDateString('default', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  const dateEl = createTag('p', { class: 'post-date' }, dateStr);
+  cardContent.appendChild(dateEl);
+
+  // Author
+  if (metadata.author) {
+    const author = createTag('p', { class: 'post-author' }, `By ${metadata.author}`);
+    cardContent.appendChild(author);
+  }
+
+  // Excerpt
+  if (metadata.excerpt || post.description) {
+    const excerpt = createTag('p', { class: 'post-excerpt' }, metadata.excerpt || post.description);
+    cardContent.appendChild(excerpt);
+  }
+
+  postCard.appendChild(cardContent);
+
+  // Hero Image
+  if (post.image) {
+    const imageDiv = createTag('div', { class: 'card-image' });
+    const pic = createOptimizedPicture(post.image, post.title, false, [{ width: '400' }]);
+    imageDiv.appendChild(pic);
+    postCard.appendChild(imageDiv);
+  }
+
+  // Link wrapper
+  const link = createTag('a', {
+    href: post.path,
+    class: 'card-link',
+    title: `Read ${post.title}`,
+  });
+  link.appendChild(postCard);
+
+  return link;
+}
+
+async function renderArchive(block, grouped) {
+  block.innerHTML = '';
+
+  const metadataPromises = [];
+
+  grouped.forEach((group) => {
+    group.posts.forEach((post) => {
+      metadataPromises.push(
+        fetchBlogMetadata(post.path).then((metadata) => {
+          post.metadata = metadata;
+        }),
+      );
+    });
+  });
+
+  // Wait for all metadata to be fetched
+  await Promise.all(metadataPromises);
+
+  // Now render all groups and posts
+  grouped.forEach((group) => {
+    const sectionDiv = createTag('div', { class: 'blog-archive-section' });
+
+    const headerDiv = createTag('div', { class: 'blog-archive-header' });
+    const headerTitle = createTag('h2', { class: 'archive-period' }, `${group.monthName} ${group.year}`);
+    headerDiv.appendChild(headerTitle);
+    sectionDiv.appendChild(headerDiv);
+
+    const postsContainer = createTag('div', { class: 'blog-archive-posts' });
+
+    group.posts.forEach((post) => {
+      const cardLink = createPostCard(post, post.metadata || {});
+      postsContainer.appendChild(cardLink);
+    });
+
+    sectionDiv.appendChild(postsContainer);
+    block.appendChild(sectionDiv);
+  });
+
+  block.dataset.rendered = 'true';
+}
+
+export default async function decorate(block) {
+  loadBlogData();
+
+  const checkDataLoaded = () => window?.blogindex?.loaded;
+
+  if (checkDataLoaded()) {
+    const blogIndex = window.blogindex.data || [];
+    const sortedBlogs = blogIndex.sort((a, b) => {
+      const dateA = new Date(a.publicationDate);
+      const dateB = new Date(b.publicationDate);
+      return dateB - dateA;
+    });
+    const grouped = groupPostsByYearMonth(sortedBlogs);
+    await renderArchive(block, grouped);
+  } else {
+    document.addEventListener('dataset-ready', async () => {
+      if (checkDataLoaded() && block.dataset.rendered !== 'true') {
+        const blogIndex = window.blogindex.data || [];
+        const sortedBlogs = blogIndex.sort((a, b) => {
+          const dateA = new Date(a.publicationDate);
+          const dateB = new Date(b.publicationDate);
+          return dateB - dateA;
+        });
+        const grouped = groupPostsByYearMonth(sortedBlogs);
+        await renderArchive(block, grouped);
+      }
+    });
+  }
+}

--- a/docs/blog-archive.md
+++ b/docs/blog-archive.md
@@ -1,0 +1,8 @@
+---
+title: Blog Archive
+description: Chronological archive of all blog posts
+---
+
+# Blog Archive
+
+## Blog Archive

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -8,6 +8,10 @@ indices:
         select: head > meta[property="og:title"]
         value: |
           attribute(el, 'content')
+      author:
+        select: head > meta[name="author"]
+        value: |
+          attribute(el, 'content')
       image:
         select: head > meta[property="og:image"]
         value: |


### PR DESCRIPTION
# Blog Archive Implementation

Creates a new blog archive block that displays all blog posts grouped chronologically by year and month.

## Changes
- **New Block**: Added `blog-archive` block to display archived blog posts
- **Index Update**: Added `author` field to helix-query.yaml for metadata extraction
- **Test Page**: Created blog archive page at /docs/blog-archive

## Features
- Displays blog posts grouped by year and month (newest first)
- Shows post title, publication date, author, excerpt, and hero image
- Fetches additional metadata (author, excerpt) from individual blog post HTML
- Responsive card layout (mobile-first, optimized for tablet and desktop)
- Accessible link structure with proper ARIA titles

## Testing
- Archive page: https://copilot-1--helix-website--adobe.aem.page/docs/blog-archive
- All linting checks pass (ESLint and Stylelint)

---
🤖 *Generated with GitHub Copilot CLI (Claude 3.5 Sonnet)*