### PR TITLE
page import skill cleanup

### DIFF
--- a/.claude/skills/authoring-analysis/SKILL.md
+++ b/.claude/skills/authoring-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoring-analysis
-description: Analyze content sequences and determine authoring approach (default content vs blocks). Validates block selection and section styling for Edge Delivery Services import/migration.
+description: Analyze content sequences and determine authoring approach (default content vs blocks). Validates block selection and section styling for import/migration to AEM Edge Delivery Services.
 ---
 
 # Authoring Analysis

--- a/.claude/skills/block-inventory/SKILL.md
+++ b/.claude/skills/block-inventory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: block-inventory
-description: Survey available blocks from local project and Block Collection to understand the block palette available for authoring. Returns block inventory with purposes to inform content modeling decisions.
+description: Survey available blocks from local AEM Edge Delivery Services project and Block Collection to understand the block palette available for authoring. Returns block inventory with purposes to inform content modeling decisions.
 ---
 
 # Block Inventory

--- a/.claude/skills/docs-search/SKILL.md
+++ b/.claude/skills/docs-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Searching AEM Documentation
-description: Searches the aem.live documentation for information on features of the platform. Use this skill when you need more information about a feature, want guidance on how to implement a feature, and using existing tools you have to search the web isn't turning up relevant results.
+description: Searches the aem.live documentation for information on AEM Edge Delivery Services features. Use this skill when you need more information about a feature, want guidance on how to implement a feature, and using existing tools you have to search the web isn't turning up relevant results.
 ---
 
 # Searching AEM Documentation

--- a/.claude/skills/generate-import-html/SKILL.md
+++ b/.claude/skills/generate-import-html/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: generate-import-html
-description: Generate Edge Delivery Services-compliant HTML from authoring analysis. Creates section structure, applies block tables, handles metadata, and manages images folder.
+description: Generate structured HTML from authoring analysis for AEM Edge Delivery Services. Creates section structure, applies block tables, handles metadata, and manages images folder.
 ---
 
 # Generate Import HTML
 
-Create plain HTML file with EDS block structure from authoring analysis.
+Create plain HTML file with block structure from authoring analysis.
 
 ## When to Use This Skill
 
@@ -136,34 +136,34 @@ From previous skills, you need:
 
 **1. Review extracted metadata from metadata.json**
 
-**2. Map each property to EDS format:**
+**2. Map each property to standard format:**
 
 **Title:**
 - Compare source `title` (or `og:title`) with first H1 on page
-- If matches first H1 → Omit (EDS defaults to H1)
+- If matches first H1 → Omit (platform defaults to H1)
 - If differs → Include as `title` property
 
 **Description:**
 - Compare source `description` (or `og:description`) with first paragraph
-- If matches first paragraph → Consider omitting (EDS defaults to first paragraph)
+- If matches first paragraph → Consider omitting (platform defaults to first paragraph)
 - If differs OR more descriptive → Include as `description` property
 - Check: 150-160 characters ideal
 
 **Image:**
 - Check source `og:image`
-- If matches first content image → Consider omitting (EDS defaults to first image)
+- If matches first content image → Consider omitting (platform defaults to first image)
 - If custom social image → Include as `image` property
 - Ensure absolute URL or correct relative path
 - Check: 1200x630 pixels recommended
 
 **Canonical:**
-- If points to same page URL → Omit (EDS auto-generates)
+- If points to same page URL → Omit (platform auto-generates)
 - If points to different page → Include as `canonical` property
 
 **Tags:**
 - Map `article:tag` or `keywords` → comma-separated `tags` property
 
-**Properties to SKIP** (EDS auto-populates):
+**Properties to SKIP** (platform auto-populates):
 - `og:url`, `og:title`, `og:description`, `twitter:title`, `twitter:description`, `twitter:image`
 - `viewport`, `charset`, `X-UA-Compatible` (belong in head.html)
 
@@ -258,7 +258,7 @@ This skill provides:
 - ✅ HTML file at correct path (e.g., `us/en/about.plain.html`)
 - ✅ Images folder in same directory (e.g., `us/en/images/`)
 - ✅ Complete content import (all sections)
-- ✅ Proper EDS block structure
+- ✅ Proper block structure
 - ✅ Section metadata applied per validation
 - ✅ Page metadata block included
 

--- a/.claude/skills/generate-import-html/resources/metadata-extraction.md
+++ b/.claude/skills/generate-import-html/resources/metadata-extraction.md
@@ -1,16 +1,16 @@
 # Metadata Extraction
 
-Extract and map metadata from source webpages to Edge Delivery Services-compliant metadata structure.
+Extract and map metadata from source webpages to standard metadata structure.
 
 ## Purpose
 
-Metadata extraction preserves SEO and social sharing properties when migrating pages to Edge Delivery Services. This resource explains how to map source page metadata to EDS-compliant properties.
+Metadata extraction preserves SEO and social sharing properties when migrating pages. This resource explains how to map source page metadata to standard properties.
 
 ## Key Principles
 
-### Leverage EDS Defaults
+### Leverage Platform Defaults
 
-EDS automatically generates metadata from page content when not explicitly provided:
+The platform automatically generates metadata from page content when not explicitly provided:
 
 - **Title** → Defaults to first H1
 - **Description** → Defaults to first paragraph (10+ words)
@@ -19,9 +19,9 @@ EDS automatically generates metadata from page content when not explicitly provi
 
 **Only include metadata when it differs from defaults.**
 
-### EDS Special Properties
+### Special Properties
 
-EDS provides convenience properties that auto-populate multiple metadata tags:
+The platform provides convenience properties that auto-populate multiple metadata tags:
 
 - `title` → Auto-populates `og:title`, `twitter:title`, `<title>`
 - `description` → Auto-populates `og:description`, `twitter:description`
@@ -38,7 +38,7 @@ Metadata is extracted automatically by the `analyze-webpage.js` script during St
 - `<link rel="canonical">` href
 - JSON-LD structured data (`<script type="application/ld+json">`)
 
-## Mapping to EDS Properties
+## Mapping to Standard Properties
 
 Use the `metadata-mapping.md` resource for detailed mapping rules. Key decision points:
 
@@ -48,7 +48,7 @@ Use the `metadata-mapping.md` resource for detailed mapping rules. Key decision 
 ```
 Source has <title> tag?
 ├─ Matches first H1 on page?
-│  └─ Omit (use EDS default)
+│  └─ Omit (use platform default)
 └─ Differs from first H1?
    └─ Include as "title" property
 ```
@@ -64,7 +64,7 @@ Source has <title> tag?
 ```
 Source has meta description?
 ├─ Matches first paragraph?
-│  └─ Consider omitting (use EDS default)
+│  └─ Consider omitting (use platform default)
 ├─ More descriptive than first paragraph?
 │  └─ Include as "description" property
 └─ Differs significantly?
@@ -82,7 +82,7 @@ Source has meta description?
 ```
 Source has og:image?
 ├─ Matches first content image?
-│  └─ Consider omitting (use EDS default)
+│  └─ Consider omitting (use platform default)
 ├─ Custom social image?
 │  └─ Include as "image" property
 └─ No og:image?
@@ -100,7 +100,7 @@ Source has og:image?
 ```
 Source has canonical link?
 ├─ Points to same page?
-│  └─ Omit (EDS auto-generates)
+│  └─ Omit (platform auto-generates)
 ├─ Points to different page?
 │  └─ Include as "canonical" property (syndicated content)
 └─ Uses .html extension?
@@ -129,7 +129,7 @@ Multiple sources?
 - `X-UA-Compatible`
 - `theme-color`
 
-**Auto-populated by EDS (redundant):**
+**Auto-populated by platform (redundant):**
 - `og:url` (use canonical instead)
 - `og:title` (use title instead)
 - `og:description` (use description instead)
@@ -241,9 +241,9 @@ When generating metadata blocks, document why properties were included or omitte
 - **tags**: "e-commerce, widgets, online shopping" - Mapped from article:tag properties
 
 ### Omitted Properties
-- **canonical**: Points to same page URL - EDS will auto-generate
-- **og:title, twitter:title**: Redundant - EDS auto-populates from title
-- **og:description**: Redundant - EDS auto-populates from description
+- **canonical**: Points to same page URL - platform will auto-generate
+- **og:title, twitter:title**: Redundant - platform auto-populates from title
+- **og:description**: Redundant - platform auto-populates from description
 - **viewport**: Technical metadata - Belongs in head.html
 
 ### Recommendations
@@ -259,8 +259,8 @@ Before finalizing the metadata block:
 - ✅ **Description**: 150-160 characters
 - ✅ **Image**: Absolute URL or correct relative path
 - ✅ **Image**: 1200x630 pixels for optimal social sharing
-- ✅ **No redundancy**: Removed og:*/twitter:* properties that EDS auto-populates
-- ✅ **Defaults leveraged**: Omitted properties that match EDS defaults
+- ✅ **No redundancy**: Removed og:*/twitter:* properties that platform auto-populates
+- ✅ **Defaults leveraged**: Omitted properties that match platform defaults
 
 ## Troubleshooting
 
@@ -305,7 +305,7 @@ const absoluteImageUrl = new URL(relativeImagePath, baseUrl).href;
 ## Related Resources
 
 - **metadata-mapping.md** - Comprehensive mapping rules and examples
-- https://www.aem.live/docs/metadata - EDS metadata documentation
+- https://www.aem.live/docs/metadata - Platform metadata documentation
 - https://www.aem.live/developer/block-collection/metadata - Metadata block reference
 
 ## Integration Notes
@@ -314,7 +314,7 @@ The metadata extraction process is integrated into the page-import workflow:
 
 1. **Step 1**: `analyze-webpage.js` extracts raw metadata from source page
 2. **Step 2-3**: Analyze content structure (identify H1, first paragraph, first image)
-3. **Step 4**: Map metadata to EDS properties, generate metadata block
+3. **Step 4**: Map metadata to standard properties, generate metadata block
 4. **Step 5**: Append metadata block to end of generated HTML (unless user explicitly skips)
 
 The metadata block is included by default. To skip: user must explicitly request "no metadata" or "skip metadata".

--- a/.claude/skills/generate-import-html/resources/metadata-mapping.md
+++ b/.claude/skills/generate-import-html/resources/metadata-mapping.md
@@ -1,8 +1,8 @@
 # Metadata Mapping Reference
 
-Detailed mapping rules for converting source webpage metadata to EDS metadata properties.
+Detailed mapping rules for converting source webpage metadata to standard metadata properties.
 
-## EDS Special Properties Reference
+## Special Properties Reference
 
 ### canonical
 - **Used in:** `<link rel="canonical">`, `<meta property="og:url">`, `<meta name="twitter:url">`
@@ -52,20 +52,20 @@ Detailed mapping rules for converting source webpage metadata to EDS metadata pr
 ### Title Mapping
 
 ```
-Source                    → EDS Property
+Source                    → Property
 ──────────────────────────────────────────
 <title>                   → title (only if differs from first H1)
 og:title                  → title (if different from <title>)
 twitter:title             → title (if different from <title>)
 
-Note: EDS auto-populates og:title and twitter:title from title
+Note: Platform auto-populates og:title and twitter:title from title
 ```
 
 **Decision Logic:**
 1. Extract `<title>`, `og:title`, `twitter:title` from source
 2. If all consistent → Use single `title` property
 3. If inconsistent → Document conflict, choose best one (typically `<title>`)
-4. If title will match first H1 in content → Omit (rely on EDS default)
+4. If title will match first H1 in content → Omit (rely on platform default)
 
 **Examples:**
 
@@ -77,7 +77,7 @@ Source:
   <meta name="twitter:title" content="About Us | Acme Corp">
   Page has H1: "About Our Company"
 
-EDS Metadata:
+Metadata:
   title: About Us | Acme Corp
 
 Reason: Title is consistent across sources but differs from H1
@@ -89,10 +89,10 @@ Source:
   <title>About Our Company</title>
   Page has H1: "About Our Company"
 
-EDS Metadata:
+Metadata:
   (omit title property)
 
-Reason: EDS will use H1 as default
+Reason: Platform will use H1 as default
 ```
 
 ```markdown
@@ -101,7 +101,7 @@ Source:
   <title>About Us | Acme Corp</title>
   <meta property="og:title" content="Learn About Acme Corporation">
 
-EDS Metadata:
+Metadata:
   title: About Us | Acme Corp
 
 Note: Document the conflict. Chose <title> as primary.
@@ -113,13 +113,13 @@ Alternative: Use og:title value if it's better for social sharing.
 ### Description Mapping
 
 ```
-Source                    → EDS Property
+Source                    → Property
 ──────────────────────────────────────────
 <meta name="description"> → description
 og:description            → description (if different from meta description)
 twitter:description       → description (if different from meta description)
 
-Note: EDS auto-populates og:description and twitter:description from description
+Note: Platform auto-populates og:description and twitter:description from description
 ```
 
 **Decision Logic:**
@@ -136,7 +136,7 @@ Source:
   <meta name="description" content="Learn about our company history and values">
   <meta property="og:description" content="Learn about our company history and values">
 
-EDS Metadata:
+Metadata:
   description: Learn about our company history and values
 ```
 
@@ -146,10 +146,10 @@ Source:
   <meta name="description" content="Welcome to our website">
   First paragraph: "Welcome to our website. We are glad you're here."
 
-EDS Metadata:
+Metadata:
   (consider omitting description)
 
-Note: EDS will use first paragraph. Consider if meta description is sufficient.
+Note: Platform will use first paragraph. Consider if meta description is sufficient.
 ```
 
 ---
@@ -157,12 +157,12 @@ Note: EDS will use first paragraph. Consider if meta description is sufficient.
 ### Image Mapping
 
 ```
-Source                    → EDS Property
+Source                    → Property
 ──────────────────────────────────────────
 og:image                  → image
 twitter:image             → image (if different from og:image)
 
-Note: EDS auto-populates og:image and twitter:image from image
+Note: Platform auto-populates og:image and twitter:image from image
 ```
 
 **Decision Logic:**
@@ -179,7 +179,7 @@ Source:
   <meta property="og:image" content="https://example.com/social-share.jpg">
   First image on page: hero-background.jpg
 
-EDS Metadata:
+Metadata:
   image: https://example.com/social-share.jpg
 
 Reason: Custom social sharing image differs from first page image
@@ -191,10 +191,10 @@ Source:
   <meta property="og:image" content="https://example.com/hero.jpg">
   First image on page: https://example.com/hero.jpg
 
-EDS Metadata:
+Metadata:
   (consider omitting image)
 
-Reason: EDS will use first image as default
+Reason: Platform will use first image as default
 ```
 
 ---
@@ -202,17 +202,17 @@ Reason: EDS will use first image as default
 ### Canonical Mapping
 
 ```
-Source                         → EDS Property
+Source                         → Property
 ─────────────────────────────────────────────
 <link rel="canonical">         → canonical (only if custom URL needed)
 og:url                         → canonical (if consistent with link rel)
 twitter:url                    → canonical (if consistent with link rel)
 
-Note: EDS auto-generates canonical if omitted
+Note: Platform auto-generates canonical if omitted
 ```
 
 **Decision Logic:**
-1. If canonical points to same page → Omit (EDS auto-generates)
+1. If canonical points to same page → Omit (Platform auto-generates)
 2. If canonical points to different page → Include (syndicated content)
 3. If URL needs extension → Consider `canonical:extension` in bulk metadata
 
@@ -224,10 +224,10 @@ Source:
   <link rel="canonical" href="https://example.com/about">
   Current page: https://example.com/about
 
-EDS Metadata:
+Metadata:
   (omit canonical)
 
-Reason: EDS will auto-generate canonical for same page
+Reason: Platform will auto-generate canonical for same page
 ```
 
 ```markdown
@@ -236,7 +236,7 @@ Source:
   <link rel="canonical" href="https://originalsource.com/article">
   Current page: https://example.com/republished-article
 
-EDS Metadata:
+Metadata:
   canonical: https://originalsource.com/article
 
 Reason: Points to original source for syndicated content
@@ -247,7 +247,7 @@ Reason: Points to original source for syndicated content
 ### Tags Mapping
 
 ```
-Source                    → EDS Property
+Source                    → Property
 ──────────────────────────────────────────
 article:tag (multiple)    → tags (comma-separated or bullet list)
 keywords                  → tags (if article:tag not present)
@@ -266,7 +266,7 @@ Source:
   <meta property="article:tag" content="performance">
   <meta property="article:tag" content="edge delivery">
 
-EDS Metadata:
+Metadata:
   tags: web development, performance, edge delivery
 ```
 
@@ -276,7 +276,7 @@ Source:
   <meta name="keywords" content="web, development, seo">
   (no article:tag present)
 
-EDS Metadata:
+Metadata:
   tags: web, development, seo
 ```
 
@@ -285,7 +285,7 @@ EDS Metadata:
 ### Other Standard Properties
 
 ```
-Source                    → EDS Property
+Source                    → Property
 ──────────────────────────────────────────
 author / article:author   → author
 robots                    → robots
@@ -307,9 +307,9 @@ Skip these - they belong in `head.html`:
 - `X-UA-Compatible`
 - `theme-color`
 
-### Auto-populated by EDS
+### Auto-populated by Platform
 
-Skip these - EDS generates from canonical/title/description:
+Skip these - platform generates from canonical/title/description:
 - `og:url` (if same as canonical)
 - `twitter:url` (if same as canonical)
 - `og:title` (if same as title)
@@ -328,7 +328,7 @@ Skip these - EDS generates from canonical/title/description:
 - `robots`
 - `canonical` (if points elsewhere)
 
-### Social Sharing (map to EDS special properties)
+### Social Sharing (map to special properties)
 - `og:title` → `title`
 - `og:description` → `description`
 - `og:image` → `image`

--- a/.claude/skills/identify-page-structure/SKILL.md
+++ b/.claude/skills/identify-page-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: identify-page-structure
-description: Identify section boundaries and content sequences within a scraped webpage. Performs two-level analysis (sections, then sequences per section) and surveys available blocks.
+description: Identify section boundaries and content sequences within a scraped webpage for AEM Edge Delivery Services import. Performs two-level analysis (sections, then sequences per section) and surveys available blocks.
 ---
 
 # Identify Page Structure
@@ -33,7 +33,7 @@ From scrape-webpage skill, you need:
 
 ## Key Concepts
 
-**CRITICAL:** EDS content has a strict two-level hierarchy:
+**CRITICAL:** Content follows a strict two-level hierarchy:
 
 ```
 DOCUMENT

--- a/.claude/skills/page-decomposition/SKILL.md
+++ b/.claude/skills/page-decomposition/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: page-decomposition
-description: Analyze content sequences within a section and provide neutral descriptions. Invoked per section during page import to identify breaking points between default content and blocks.
+description: Analyze content sequences within a section and provide neutral descriptions for AEM Edge Delivery Services. Invoked per section during page import to identify breaking points between default content and blocks.
 ---
 
 # Page Decomposition
 
-Analyze content sequences within an EDS section and provide neutral descriptions without assigning block names.
+Analyze content sequences within a section and provide neutral descriptions without assigning block names.
 
 ## When to Use This Skill
 
@@ -34,7 +34,7 @@ From the calling skill (identify-page-structure), you need:
 
 ## Key Concepts
 
-**EDS Content Hierarchy:**
+**Content Hierarchy:**
 ```
 DOCUMENT
 ├── SECTION (top-level, analyzed by identify-page-structure Step 2a)
@@ -160,7 +160,7 @@ Provide content sequences for this section in structured format.
 
 ## Section Metadata Format
 
-**Markdown format:**
+**Table format:**
 ```markdown
 +------------------------------+
 | Section Metadata             |

--- a/.claude/skills/page-import/SKILL.md
+++ b/.claude/skills/page-import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: page-import
-description: Import a single webpage from any URL to Edge Delivery Services-compliant HTML content. Scrapes the page, analyzes structure, maps to existing blocks, and generates HTML for immediate local preview. Also triggered by terms like "migrate", "migration", or "migrating".
+description: Import a single webpage from any URL to structured HTML content for authoring in AEM Edge Delivery Services. Scrapes the page, analyzes structure, maps to existing blocks, and generates HTML for immediate local preview. Also triggered by terms like "migrate", "migration", or "migrating".
 ---
 
 # Page Import Orchestrator
@@ -10,7 +10,7 @@ You are an orchestrator of a website page import/migration. You have specialized
 ## When to Use This Skill
 
 Use this skill when:
-- Importing or migrating individual pages from existing websites to Edge Delivery Services
+- Importing or migrating individual pages from existing websites
 - Converting competitor pages for reference or analysis
 - Creating content files from design prototypes or staging sites
 
@@ -39,7 +39,7 @@ This orchestrator delegates work to:
 - **scrape-webpage** - Extract content, metadata, and images from source URL
 - **identify-page-structure** - Identify section boundaries and content sequences
 - **authoring-analysis** - Make authoring decisions (default content vs blocks)
-- **generate-import-html** - Create EDS-compliant HTML file
+- **generate-import-html** - Create structured HTML file
 - **preview-import** - Verify in local dev server
 
 These skills invoke additional skills as needed:

--- a/.claude/skills/preview-import/SKILL.md
+++ b/.claude/skills/preview-import/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preview-import
-description: Preview and verify imported content in local dev server. Validates rendering, compares with original page, and troubleshoots common issues.
+description: Preview and verify imported content in local AEM Edge Delivery Services dev server. Validates rendering, compares with original page, and troubleshoots common issues.
 ---
 
 # Preview Import
@@ -97,7 +97,7 @@ Use `paths.documentPath` from metadata.json, but for index files ensure the path
 ## Troubleshooting
 
 **Blocks don't render correctly:**
-- Check HTML structure matches EDS format
+- Check HTML structure matches expected format
 - Verify block names match exactly (case-sensitive)
 - Review `../page-import/resources/html-structure.md` for format guidance
 
@@ -114,7 +114,7 @@ Use `paths.documentPath` from metadata.json, but for index files ensure the path
 **Metadata not in page source:**
 - Check metadata block is at end of HTML file
 - View page source and search for `<meta>` tags in `<head>`
-- Verify metadata properties match EDS format
+- Verify metadata properties match expected format
 
 **Dev server not running:**
 - Start server with `aem up`

--- a/.claude/skills/scrape-webpage/SKILL.md
+++ b/.claude/skills/scrape-webpage/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: scrape-webpage
-description: Scrape webpage content, extract metadata, download images, and prepare for Edge Delivery Services import/migration. Returns analysis JSON with paths, metadata, cleaned HTML, and local images.
+description: Scrape webpage content, extract metadata, download images, and prepare for import/migration to AEM Edge Delivery Services. Returns analysis JSON with paths, metadata, cleaned HTML, and local images.
 ---
 
 # Scrape Webpage
 
-Extract content, metadata, and images from a webpage for Edge Delivery Services import/migration.
+Extract content, metadata, and images from a webpage for import/migration.
 
 ## When to Use This Skill
 
@@ -49,7 +49,7 @@ node .claude/skills/scrape-webpage/scripts/analyze-webpage.js "https://example.c
 7. **Fixes images in DOM** (background-image→img, picture elements, srcset→src, relative→absolute, inline SVG→img)
 8. Extracts cleaned HTML (removes scripts/styles)
 9. Replaces image URLs in HTML with local paths (./images/...)
-10. Generates Edge Delivery Services document paths (sanitized, lowercase, no .html)
+10. Generates document paths (sanitized, lowercase, no .html extension)
 11. Saves complete analysis with image mapping to metadata.json
 
 **For detailed explanation:** See `resources/web-page-analysis.md`

--- a/.claude/skills/scrape-webpage/resources/web-page-analysis.md
+++ b/.claude/skills/scrape-webpage/resources/web-page-analysis.md
@@ -168,7 +168,7 @@ Extracts SEO and social metadata:
 
 ### 7. Document Path Generation
 
-Generates Edge Delivery Services-compliant document paths from the source URL:
+Generates document paths from the source URL:
 
 **Algorithm:**
 1. Extracts pathname from URL
@@ -353,5 +353,5 @@ After running web page analysis:
 1. Review screenshots to understand page structure
 2. Examine enhanced-contrast.png to identify section boundaries
 3. Use cleaned HTML to map content to blocks
-4. Use metadata to generate EDS metadata block
+4. Use metadata to generate metadata block
 5. Proceed with page-import Steps 2-5

--- a/.claude/skills/scrape-webpage/scripts/analyze-webpage.js
+++ b/.claude/skills/scrape-webpage/scripts/analyze-webpage.js
@@ -393,7 +393,7 @@ async function analyzeWebpage(url, outputDir) {
     fs.writeFileSync(htmlPath, html, 'utf-8');
 
     // Generate document paths
-    console.error('Generating EDS document paths...');
+    console.error('Generating document paths...');
     const paths = generateDocumentPathInfo(url);
 
     // Build result object

--- a/.claude/skills/scrape-webpage/scripts/generate-path.js
+++ b/.claude/skills/scrape-webpage/scripts/generate-path.js
@@ -13,8 +13,8 @@
  */
 
 /**
- * Path generation script for Edge Delivery Services page migration
- * Generates Edge Delivery Services-compliant document paths from source URLs
+ * Path generation script for page migration
+ * Generates document paths from source URLs
  *
  * This uses the exact same algorithm as the EXCAT MCP tool's generate_document_path
  * to ensure consistent path generation across all migration workflows.
@@ -44,7 +44,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
- * Sanitize a filename according to AEM Edge Delivery Services naming conventions
+ * Sanitize a filename according to standard naming conventions
  * @param {string} name - The filename to sanitize
  * @returns {string} - Sanitized filename
  */
@@ -59,7 +59,7 @@ function sanitizeFilename(name) {
 }
 
 /**
- * Sanitize a path according to AEM Edge Delivery Services naming conventions
+ * Sanitize a path according to standard naming conventions
  * @param {string} pathStr - The path to sanitize
  * @returns {string} - Sanitized path
  */
@@ -80,7 +80,7 @@ function sanitizePath(pathStr) {
 }
 
 /**
- * Generate Edge Delivery Services document path from URL according to AEM Edge Delivery Services conventions
+ * Generate document path from URL according to standard conventions
  * @param {string} url - Source URL
  * @returns {string} - Document path (without extension)
  */
@@ -103,7 +103,7 @@ function generateDocumentPath({ url }) {
  */
 function generateDocumentPathInfo(url) {
   try {
-    // Generate the Edge Delivery Services document path (no extension)
+    // Generate the document path (no extension)
     const documentPath = generateDocumentPath({ url });
 
     // Build file paths


### PR DESCRIPTION
As discussed with you @shsteimer, here is a PR to cleanup the new skills:

- use "import" instead of "migrate" / "migration"
- only use "AEM Edge Delivery Services" once at the top of each skill just to help set the context of execution