### PR TITLE
feat(ue-trial): add hidden input for agentic playground scope in form

### DIFF
--- a/blocks/ue-trial/ue-trial.js
+++ b/blocks/ue-trial/ue-trial.js
@@ -630,7 +630,7 @@ async function buildForm(block) {
 
   // Submit button
   const buttonContainer = createTag('div', { class: 'button-container' });
-  
+
   const isAgenticPlaygournd = block.classList.contains('agentic-playground');
   if (isAgenticPlaygournd) {
     const hiddenScopeInput = createTag('input', {
@@ -638,7 +638,7 @@ async function buildForm(block) {
       name: 'scope',
       value: 'agentic-playground',
     });
-    buttonContainer.append(hiddenScopeInput); 
+    buttonContainer.append(hiddenScopeInput);
   }
   const submitButton = createTag('button', {
     type: 'submit',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add hidden input scope to UE trial form if block has agentic-playground option.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Based on the scope the user will retrieve a different welcome email.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Preview: https://feat-aem-playground--helix-website--adobe.aem.page/developer/aem-playground
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
