### PR TITLE
feat(ue-trial): conditionally render GitHub ID field based on agentic…

### DIFF
--- a/blocks/ue-trial/ue-trial.js
+++ b/blocks/ue-trial/ue-trial.js
@@ -558,17 +558,20 @@ async function buildForm(block) {
   });
 
   templateField.append(templateLabel, templateGrid);
-
-  // GitHub ID (moved after template)
-  const githubField = createTag('div', { class: 'form-field', id: 'github-field' });
-  const githubLabel = createTag('label', { for: 'github-id' }, 'GitHub ID (optional)');
-  const githubInput = createTag('input', {
-    type: 'text',
-    id: 'github-id',
-    name: 'githubId',
-  });
-  const githubHelpText = createTag('p', { class: 'help-text' }, 'If you provide your GitHub ID we will also set up a GitHub repo with project files so you can do code and style changes.');
-  githubField.append(githubLabel, githubInput, githubHelpText);
+  const isAgenticPlaygournd = block.classList.contains('agentic-playground');
+  let githubField = null;
+  if (!isAgenticPlaygournd) {
+    // GitHub ID (moved after template)
+    githubField = createTag('div', { class: 'form-field', id: 'github-field' });
+    const githubLabel = createTag('label', { for: 'github-id' }, 'GitHub ID (optional)');
+    const githubInput = createTag('input', {
+      type: 'text',
+      id: 'github-id',
+      name: 'githubId',
+    });
+    const githubHelpText = createTag('p', { class: 'help-text' }, 'If you provide your GitHub ID we will also set up a GitHub repo with project files so you can do code and style changes.');
+    githubField.append(githubLabel, githubInput, githubHelpText);
+  }
 
   // Terms and Conditions - extract from block content
   const agreement = createTag('div', { class: 'agreement' });
@@ -631,7 +634,6 @@ async function buildForm(block) {
   // Submit button
   const buttonContainer = createTag('div', { class: 'button-container' });
 
-  const isAgenticPlaygournd = block.classList.contains('agentic-playground');
   if (isAgenticPlaygournd) {
     const hiddenScopeInput = createTag('input', {
       type: 'hidden',
@@ -649,7 +651,7 @@ async function buildForm(block) {
   // Append all elements to form
   form.append(
     emailField,
-    githubField,
+    githubField || '',
     templateField,
     agreement,
     altchaContainer,


### PR DESCRIPTION
… playground class

<!--- Provide a general summary of your changes in the Title above -->

## Description

On the SignUp form for the AEM Agentic Playground the user should not been asked for the GitHub Id

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Preview: https://feat-aem-playground-2--helix-website--adobe.aem.page/developer/aem-playground
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
