### PR TITLE
fix(oversight): add dark mode support for charts and UI elements

### DIFF
--- a/tools/oversight/charts/barchart.js
+++ b/tools/oversight/charts/barchart.js
@@ -154,7 +154,9 @@ export default class BarChart extends AbstractChart {
             display: false,
           },
           customCanvasBackgroundColor: {
-            color: 'white',
+            color: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? '#1e1e1e'
+              : 'white',
           },
         },
         interaction: {
@@ -182,12 +184,25 @@ export default class BarChart extends AbstractChart {
             stacked: true,
             ticks: {
               callback: (value) => toHumanReadable(value),
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? '#b3b3b3'
+                : undefined,
+            },
+            grid: {
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'rgba(255, 255, 255, 0.15)'
+                : undefined,
             },
           },
           y: {
             stacked: true,
             grid: {
               display: false,
+            },
+            ticks: {
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? '#b3b3b3'
+                : undefined,
             },
           },
         },

--- a/tools/oversight/charts/cwvperf.js
+++ b/tools/oversight/charts/cwvperf.js
@@ -130,7 +130,9 @@ export default class CWVPerfChart extends AbstractChart {
             display: false,
           },
           customCanvasBackgroundColor: {
-            color: 'white',
+            color: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? '#1e1e1e'
+              : 'white',
           },
           tooltip: {
             intersect: false,
@@ -182,6 +184,9 @@ export default class CWVPerfChart extends AbstractChart {
               minRotation: 90,
               maxRotation: 90,
               autoSkip: false,
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? '#b3b3b3'
+                : undefined,
             },
           },
           y: {

--- a/tools/oversight/charts/skyline.js
+++ b/tools/oversight/charts/skyline.js
@@ -104,27 +104,38 @@ export default class SkylineChart extends AbstractChart {
                 // This case happens on initial chart load
                 return null;
               }
-              return getGradient(ctx, chartArea, cssVariable('--spectrum-gray-800'), cssVariable('--spectrum-purple-1200'));
+              const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+              // Brighter purples in dark mode with visible gradient
+              return isDark
+                ? getGradient(ctx, chartArea, cssVariable('--spectrum-purple-1100'), cssVariable('--spectrum-purple-700'))
+                : getGradient(ctx, chartArea, cssVariable('--spectrum-gray-800'), cssVariable('--spectrum-purple-1200'));
             },
             data: [],
           },
           {
             label: 'Good LCP',
-            backgroundColor: cssVariable('--spectrum-green-600'),
+            // Darker greens in dark mode to match metric indicators
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-green-900')
+              : cssVariable('--spectrum-green-600'),
             data: [],
             yAxisID: 'lcp',
             borderSkipped: 'top',
           },
           {
             label: 'Needs Improvement LCP',
-            backgroundColor: cssVariable('--spectrum-orange-600'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-orange-900')
+              : cssVariable('--spectrum-orange-600'),
             data: [],
             yAxisID: 'lcp',
             borderSkipped: true,
           },
           {
             label: 'Poor LCP',
-            backgroundColor: cssVariable('--spectrum-red-600'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-red-900')
+              : cssVariable('--spectrum-red-600'),
             data: [],
             yAxisID: 'lcp',
             borderSkipped: 'bottom',
@@ -137,22 +148,27 @@ export default class SkylineChart extends AbstractChart {
           },
           {
             label: 'Good CLS',
-            // slightly lighter green than #49cc93 which is the good LCP color
-            backgroundColor: cssVariable('--spectrum-green-500'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-green-800')
+              : cssVariable('--spectrum-green-500'),
             data: [],
             yAxisID: 'cls',
             borderSkipped: 'top',
           },
           {
             label: 'Needs Improvement CLS',
-            backgroundColor: cssVariable('--spectrum-orange-500'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-orange-800')
+              : cssVariable('--spectrum-orange-500'),
             data: [],
             yAxisID: 'cls',
             borderSkipped: true,
           },
           {
             label: 'Poor CLS',
-            backgroundColor: cssVariable('--spectrum-red-500'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-red-800')
+              : cssVariable('--spectrum-red-500'),
             data: [],
             yAxisID: 'cls',
             borderSkipped: 'bottom',
@@ -165,22 +181,27 @@ export default class SkylineChart extends AbstractChart {
           },
           {
             label: 'Good INP',
-            // slightly lighter green than #49cc93 which is the good LCP color
-            backgroundColor: cssVariable('--spectrum-green-400'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-green-700')
+              : cssVariable('--spectrum-green-400'),
             data: [],
             yAxisID: 'inp',
             borderSkipped: 'top',
           },
           {
             label: 'Needs Improvement INP',
-            backgroundColor: cssVariable('--spectrum-orange-400'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-orange-700')
+              : cssVariable('--spectrum-orange-400'),
             data: [],
             yAxisID: 'inp',
             borderSkipped: true,
           },
           {
             label: 'Poor INP',
-            backgroundColor: cssVariable('--spectrum-red-400'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-red-700')
+              : cssVariable('--spectrum-red-400'),
             data: [],
             yAxisID: 'inp',
             borderSkipped: 'bottom',
@@ -213,7 +234,9 @@ export default class SkylineChart extends AbstractChart {
             display: false,
           },
           customCanvasBackgroundColor: {
-            color: 'white',
+            color: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? '#1e1e1e'
+              : 'white',
           },
           tooltip: {
             callbacks: {
@@ -280,6 +303,9 @@ export default class SkylineChart extends AbstractChart {
               minRotation: 90,
               maxRotation: 90,
               autoSkip: false,
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? '#b3b3b3'
+                : undefined,
             },
           },
           y: {
@@ -291,6 +317,9 @@ export default class SkylineChart extends AbstractChart {
             ticks: {
               autoSkip: false,
               maxTicksLimit: 16,
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? '#b3b3b3'
+                : undefined,
               callback: (value, index, arr) => {
                 if (value === 0) return '';
                 if (value > 0) {
@@ -304,7 +333,8 @@ export default class SkylineChart extends AbstractChart {
             },
             grid: {
               color: (context) => {
-                if (context.tick.value > 0) return 'rgba(0, 0, 0, 0.1)';
+                const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                if (context.tick.value > 0) return isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.1)';
                 return 'rgba(0, 0, 0, 0.0)';
               },
             },

--- a/tools/oversight/elements/daterange-picker.js
+++ b/tools/oversight/elements/daterange-picker.js
@@ -152,6 +152,38 @@ const STYLES = `
       position: absolute;
     }
   }
+
+  @media (prefers-color-scheme: dark) {
+    input {
+      background-color: #2c2c2c;
+      border-color: #4a4a4a;
+      color: #e1e1e1;
+    }
+
+    .input-wrapper {
+      background-color: #2c2c2c;
+    }
+
+    input[data-custom='true'] ~ .input-wrapper {
+      background-color: #2c2c2c;
+      border-color: #4a4a4a;
+      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+    }
+
+    ul {
+      background-color: #2c2c2c;
+      border-color: #4a4a4a;
+      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+    }
+
+    ul.menu li:last-child::before {
+      background-color: #4a4a4a;
+    }
+
+    input ~ ul li:hover {
+      background-color: #3e3e3e;
+    }
+  }
 `;
 
 const TEMPLATE = `

--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -1278,3 +1278,23 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
 footer.footer-wrapper.appear {
   display: none;
 }
+
+/* dark mode */
+@media (prefers-color-scheme: dark) {
+  /* key metrics boxes - use subtle gray, not stark black */
+  .key-metrics > ul > * {
+    background-color: #2c2c2c;
+  }
+
+  /* quick filter input */
+  .quick-filter input {
+    background-color: #2c2c2c;
+    color: var(--spectrum-gray-100);
+    border-bottom-color: var(--spectrum-gray-600);
+  }
+
+  /* daterange-picker */
+  daterange-picker {
+    color: var(--spectrum-gray-100);
+  }
+}

--- a/tools/rum/charts/skyline.js
+++ b/tools/rum/charts/skyline.js
@@ -114,27 +114,38 @@ export default class SkylineChart extends AbstractChart {
                 // This case happens on initial chart load
                 return null;
               }
-              return getGradient(ctx, chartArea, cssVariable('--spectrum-gray-800'), cssVariable('--spectrum-purple-1200'));
+              const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+              // Brighter purples in dark mode with visible gradient
+              return isDark
+                ? getGradient(ctx, chartArea, cssVariable('--spectrum-purple-1100'), cssVariable('--spectrum-purple-700'))
+                : getGradient(ctx, chartArea, cssVariable('--spectrum-gray-800'), cssVariable('--spectrum-purple-1200'));
             },
             data: [],
           },
           {
             label: 'Good LCP',
-            backgroundColor: cssVariable('--spectrum-green-600'),
+            // Darker greens in dark mode to match metric indicators
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-green-900')
+              : cssVariable('--spectrum-green-600'),
             data: [],
             yAxisID: 'lcp',
             borderSkipped: 'top',
           },
           {
             label: 'Needs Improvement LCP',
-            backgroundColor: cssVariable('--spectrum-orange-600'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-orange-900')
+              : cssVariable('--spectrum-orange-600'),
             data: [],
             yAxisID: 'lcp',
             borderSkipped: true,
           },
           {
             label: 'Poor LCP',
-            backgroundColor: cssVariable('--spectrum-red-600'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-red-900')
+              : cssVariable('--spectrum-red-600'),
             data: [],
             yAxisID: 'lcp',
             borderSkipped: 'bottom',
@@ -147,22 +158,27 @@ export default class SkylineChart extends AbstractChart {
           },
           {
             label: 'Good CLS',
-            // slightly lighter green than #49cc93 which is the good LCP color
-            backgroundColor: cssVariable('--spectrum-green-500'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-green-800')
+              : cssVariable('--spectrum-green-500'),
             data: [],
             yAxisID: 'cls',
             borderSkipped: 'top',
           },
           {
             label: 'Needs Improvement CLS',
-            backgroundColor: cssVariable('--spectrum-orange-500'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-orange-800')
+              : cssVariable('--spectrum-orange-500'),
             data: [],
             yAxisID: 'cls',
             borderSkipped: true,
           },
           {
             label: 'Poor CLS',
-            backgroundColor: cssVariable('--spectrum-red-500'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-red-800')
+              : cssVariable('--spectrum-red-500'),
             data: [],
             yAxisID: 'cls',
             borderSkipped: 'bottom',
@@ -175,22 +191,27 @@ export default class SkylineChart extends AbstractChart {
           },
           {
             label: 'Good INP',
-            // slightly lighter green than #49cc93 which is the good LCP color
-            backgroundColor: cssVariable('--spectrum-green-400'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-green-700')
+              : cssVariable('--spectrum-green-400'),
             data: [],
             yAxisID: 'inp',
             borderSkipped: 'top',
           },
           {
             label: 'Needs Improvement INP',
-            backgroundColor: cssVariable('--spectrum-orange-400'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-orange-700')
+              : cssVariable('--spectrum-orange-400'),
             data: [],
             yAxisID: 'inp',
             borderSkipped: true,
           },
           {
             label: 'Poor INP',
-            backgroundColor: cssVariable('--spectrum-red-400'),
+            backgroundColor: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? cssVariable('--spectrum-red-700')
+              : cssVariable('--spectrum-red-400'),
             data: [],
             yAxisID: 'inp',
             borderSkipped: 'bottom',
@@ -223,7 +244,9 @@ export default class SkylineChart extends AbstractChart {
             display: false,
           },
           customCanvasBackgroundColor: {
-            color: 'white',
+            color: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? '#1e1e1e'
+              : 'white',
           },
           tooltip: {
             callbacks: {
@@ -290,6 +313,9 @@ export default class SkylineChart extends AbstractChart {
               minRotation: 90,
               maxRotation: 90,
               autoSkip: false,
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? '#b3b3b3'
+                : undefined,
             },
           },
           y: {
@@ -301,6 +327,9 @@ export default class SkylineChart extends AbstractChart {
             ticks: {
               autoSkip: false,
               maxTicksLimit: 16,
+              color: window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? '#b3b3b3'
+                : undefined,
               callback: (value, index, arr) => {
                 if (value === 0) return '';
                 if (value > 0) {
@@ -314,7 +343,8 @@ export default class SkylineChart extends AbstractChart {
             },
             grid: {
               color: (context) => {
-                if (context.tick.value > 0) return 'rgba(0, 0, 0, 0.1)';
+                const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                if (context.tick.value > 0) return isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(0, 0, 0, 0.1)';
                 return 'rgba(0, 0, 0, 0.0)';
               },
             },

--- a/tools/rum/elements/daterange-picker.js
+++ b/tools/rum/elements/daterange-picker.js
@@ -152,6 +152,38 @@ const STYLES = `
       position: absolute;
     }
   }
+
+  @media (prefers-color-scheme: dark) {
+    input {
+      background-color: #2c2c2c;
+      border-color: #4a4a4a;
+      color: #e1e1e1;
+    }
+
+    .input-wrapper {
+      background-color: #2c2c2c;
+    }
+
+    input[data-custom='true'] ~ .input-wrapper {
+      background-color: #2c2c2c;
+      border-color: #4a4a4a;
+      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+    }
+
+    ul {
+      background-color: #2c2c2c;
+      border-color: #4a4a4a;
+      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+    }
+
+    ul.menu li:last-child::before {
+      background-color: #4a4a4a;
+    }
+
+    input ~ ul li:hover {
+      background-color: #3e3e3e;
+    }
+  }
 `;
 
 const TEMPLATE = `

--- a/tools/rum/rum-slicer.css
+++ b/tools/rum/rum-slicer.css
@@ -944,3 +944,23 @@ img.facet-thumbnail {
   aspect-ratio: 1/1;
   object-fit: contain;
 }
+
+/* dark mode */
+@media (prefers-color-scheme: dark) {
+  /* key metrics boxes - use subtle gray, not stark black */
+  .key-metrics > ul > * {
+    background-color: #2c2c2c;
+  }
+
+  /* quick filter input */
+  .quick-filter input {
+    background-color: #2c2c2c;
+    color: var(--spectrum-gray-100);
+    border-bottom-color: var(--spectrum-gray-600);
+  }
+
+  /* daterange-picker */
+  daterange-picker {
+    color: var(--spectrum-gray-100);
+  }
+}


### PR DESCRIPTION
## Summary
- Add dark mode styles for key metrics boxes, quick filter input, and daterange-picker shadow DOM
- Update Chart.js canvas background color to match page background (`#1e1e1e`) in dark mode
- Adjust chart tick labels (`#b3b3b3`) and grid lines (`rgba(255, 255, 255, 0.15)`) for better visibility in dark mode
- Update skyline chart colors: brighter purple gradient (`purple-1100` → `purple-700`), darker CWV colors (green/orange/red-900/800/700)
- Apply same changes to tools/rum for consistency

## Test plan
- [ ] View oversight explorer in dark mode: https://claude-2--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=www.aem.live&view=month&domainkey=
- [ ] Verify chart background matches page background
- [ ] Verify chart text/tick labels are readable
- [ ] Verify purple bars have visible gradient
- [ ] Verify CWV colors (green/orange/red) are appropriately muted
- [ ] Verify key metrics boxes have subtle gray background (not stark black)
- [ ] Verify daterange-picker dropdown has proper dark mode styling
- [ ] Test same in light mode to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)