### PR TITLE
fix(oversight): prevent layout shift when CWV metrics load in facets

### DIFF
--- a/tools/oversight/rum-slicer.css
+++ b/tools/oversight/rum-slicer.css
@@ -1222,6 +1222,7 @@ facet-sidebar[aria-disabled="true"] div.quick-filter {
   #facets fieldset div {
     grid-template-areas: "check lab cwv";
     grid-template-columns: 20px 1fr 350px;
+    min-height: 56px;
   }
 
   #facets ul.cwv {


### PR DESCRIPTION
## Summary
- Reserve 56px min-height for facet rows at wider breakpoints (≥600px) to prevent layout shift when CWV performance metrics are lazily loaded
- The facet div rows were expanding from their initial height to 56px when the `ul.cwv` element was added with LCP, CLS, and INP metrics

## Test plan
- [ ] Open https://claude-3--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=aem.live%3Aall&filter=&view=custom&startDate=2024-12-01&endDate=2025-11-30&skyline=userAgent
- [ ] Observe that facet rows no longer shift when CWV metrics load
- [ ] Verify layout looks correct at various viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)