### PR TITLE
fix: form labels for UE Trial

### DIFF
--- a/blocks/ue-trial/ue-trial.css
+++ b/blocks/ue-trial/ue-trial.css
@@ -793,3 +793,14 @@
     font-size: 15px;
   }
 }
+
+/* Dark mode overrides for form labels */
+@media (prefers-color-scheme: dark) {
+  .ue-trial label {
+    color: var(--color-gray-700);
+  }
+
+  .ue-trial .help-text {
+    color: var(--color-gray-600);
+  }
+}


### PR DESCRIPTION
Fix form labels for UE Trial

Before:
- https://main--helix-website--adobe.aem.page/developer/aem-playground
After:
- https://dark-mode-fixes--helix-website--adobe.aem.page/developer/aem-playground