### PR TITLE
add stddev to DOM for timeOnPage metric

### DIFF
--- a/tools/oversight/elements/list-facet.js
+++ b/tools/oversight/elements/list-facet.js
@@ -489,6 +489,11 @@ export default class ListFacet extends HTMLElement {
       }
 
       li.append(nf, meter);
+
+      // add stddev for a given metric
+      if (rate === 'timeOnPage') {
+        li.dataset.stddev = entry.metrics[rate].stddev;
+      }
     };
     // fill the element, but don't wait for it
     window.setTimeout(fillEl, 0);


### PR DESCRIPTION
Follow-up to https://github.com/adobe/helix-website/pull/1024

Add standard deviation to Oversight Explorer for consumption by OpTel Detective.

https://oversight-stddev--helix-website--adobe.aem.live/tools/oversight/explorer.html?domain=emigrationbrewing.com&view=month&domainkey=open

A sample tag now looks like this, with stddev measured in milliseconds.

`<li class="business-metric timeOnPage time acquisition" title="Time on page" data-stddev="4667.515998125674">...</li>`