### PR TITLE
fix: 404 page in dark mode

### DIFF
--- a/404.html
+++ b/404.html
@@ -54,6 +54,16 @@
     main.error .error-number text {
       font-family: monospace;
     }
+
+    main.error .button-container {
+      padding-top: var(--spacing-s);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      main.error .error-number text {
+        fill: var(--color-black);
+      }
+    }
   </style>
   <link rel="stylesheet" href="/styles/lazy-styles.css">
 </head>


### PR DESCRIPTION
Fix 404 page in dark mode

Before
<img width="1341" height="777" alt="Screenshot 2025-12-17 at 3 02 02 PM" src="https://github.com/user-attachments/assets/ed7ebd98-796f-44db-a6fc-6c6f84b12126" />

After

<img width="1344" height="827" alt="Screenshot 2025-12-17 at 3 02 52 PM" src="https://github.com/user-attachments/assets/7c9acfdb-63e8-47c6-b91a-07d4a8e66730" />
