### PR TITLE
fix: doc-search Site Search only checks for sections within main

### DIFF
--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -78,7 +78,9 @@ export async function fetchSourceDataHTML(index) {
     // parse the html and return array of sections
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, 'text/html');
-    const sections = [...doc.querySelectorAll('h3')].map((h3) => h3.parentElement) || [];
+    // Only search for h3 within main content, excluding header/footer
+    const main = doc.querySelector('main') || doc;
+    const sections = [...main.querySelectorAll('h3')].map((h3) => h3.parentElement) || [];
     window.docs.push(...sections);
     const image = doc.querySelector('meta[property="og:image"]')?.content || '';
     window.faqImage = image;
@@ -261,7 +263,7 @@ function hideResults(container) {
 }
 
 function getIdFromSectionMetadata(section) {
-  const sectionId = section.parentElement?.querySelector('.section-metadata div div:nth-child(2)').textContent;
+  const sectionId = section.parentElement?.querySelector('.section-metadata div div:nth-child(2)')?.textContent;
   return sectionId;
 }
 


### PR DESCRIPTION
Fix site search (doc-search) crashing on http://www.aem.live when searching FAQ content. The issue was caused by `fetchSourceDataHTML` searching for all `<h3>` elements in the entire document, including those in the header/footer. Footer H3s don't have section-metadata, causing a null reference error in `getIdFromSectionMetadata`.

## Description
  - Scope querySelectorAll('h3') to <main> element only, excluding header/footer
  - Add defensive null check (?.) before accessing .textContent in getIdFromSectionMetadata

## Related Issue

#1036 

## Motivation and Context

The search works on main--helix-website--adobe.aem.live but fails on www.aem.live with:

```
Uncaught TypeError: Cannot read properties of null (reading 'textContent')
      at getIdFromSectionMetadata (doc-search.js:264:99)
```

Root cause: The two domains serve different HTML for header/footer:
  - https://www.aem.live: Server-side rendered (footer contains 4 H3 navigation links)
  - https://main--helix-website--adobe.aem.live: Client-side rendered (empty <footer></footer>)

When FAQ HTML is fetched and parsed, the footer H3s on http://www.aem.live were incorrectly included as FAQ sections, causing the crash when attempting to read their non-existent section-metadata.

## How Has This Been Tested?

- Verified http://www.aem.live FAQ page has 136 H3s (132 in <main>, 4 in <footer>)
  - Verified main domain FAQ page has 132 H3s (all in <main>, empty footer)
  - Confirmed fix scopes search to only the 132 legitimate FAQ H3s in <main>
  - Tested locally on localhost:3000 that it doesn't cause any regressions & sections returned are only from the `main` 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
