### PR TITLE
fix(oversight): convert dynamic facet values to strings for URL filter matching

### DIFF
--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -258,14 +258,14 @@ function updateDataFacets(filterText, params, checkpoint) {
           .map(reclassifyConsent)
           .filter((evt) => evt.checkpoint === cp)
           .filter(({ source }) => source) // filter out empty sources
-          .reduce((acc, { source }) => { acc.add(source); return acc; }, new Set()),
+          .reduce((acc, { source }) => { acc.add(String(source)); return acc; }, new Set()),
       ));
       dataChunks.addFacet(`${cp}.target`, (bundle) => Array.from(
         bundle.events
           .map(reclassifyConsent)
           .filter((evt) => evt.checkpoint === cp)
           .filter(({ target }) => target) // filter out empty targets
-          .reduce((acc, { target }) => { acc.add(target); return acc; }, new Set()),
+          .reduce((acc, { target }) => { acc.add(String(target)); return acc; }, new Set()),
       ));
 
       if (cp === 'loadresource') {


### PR DESCRIPTION
## Description
When selecting a checkpoint (e.g., redirect) and then filtering by its dynamic facet (e.g., redirect.target), the dashboard would go blank showing 0 matching bundles. This PR fixes the issue

## Related Issue
#1041 

## Motivation and Context
Fixes the issue where dashboard goes blank due to type mismatch between facet values and URL parameters

## How Has This Been Tested?
https://main--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=www.adobe.com&filter=&view=month&=performance&checkpoint=redirect&redirect.target=1&domainkey=incognito&conversion.checkpoint=click
vs
https://issue-1041--helix-website--adobe.aem.page/tools/oversight/explorer.html?domain=www.adobe.com&filter=&view=month&=performance&checkpoint=redirect&redirect.target=1&domainkey=incognito&conversion.checkpoint=click


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
