### PR TITLE
feat(ue-trial): add GitHub ID validation

### DIFF
--- a/blocks/ue-trial/ue-trial.css
+++ b/blocks/ue-trial/ue-trial.css
@@ -277,6 +277,39 @@
   line-height: 1.4;
 }
 
+/* GitHub ID validation states */
+.ue-trial .form-field.validating input {
+  border-color: #1473e6;
+}
+
+.ue-trial .form-field.valid input {
+  border-color: #28a745;
+}
+
+.ue-trial .form-field.invalid input {
+  border-color: #dc3545;
+}
+
+.ue-trial .validation-message {
+  font-size: 14px;
+  margin-top: 5px;
+  line-height: 1.4;
+}
+
+.ue-trial .validation-message.validation-success {
+  color: #28a745;
+}
+
+.ue-trial .validation-message.validation-error {
+  color: #dc3545;
+}
+
+
+.ue-trial .validation-message.validation-warning {
+  color: #f39c12;
+}
+
+
 .ue-trial .agreement {
   margin-top: 15px;
 }


### PR DESCRIPTION
Add real-time validation for the GitHub ID field using the public GitHub Users API. Features include:

- Debounced validation (800ms) after user stops typing
- Visual feedback: validating (blue), valid (green), invalid (red)
- Warning state for rate limits or network errors (orange)
- Form submission blocked when GitHub ID is invalid
- Empty field remains valid (field is optional)

Before:

https://https://main--helix-website--adobe.aem.page/developer/aem-playground
After:

https://fet-gh-id-validation--helix-website--adobe.aem.page/developer/aem-playground

Fixes #1053 