### PR TITLE
feat: rewrite /block-collection/ links

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -283,6 +283,12 @@ export function decorateGuideTemplateHero(main) {
 export function decorateGuideTemplateLinks(main) {
   const links = main.querySelectorAll('.content a');
   links.forEach((link) => {
+    const url = new URL(link.href);
+    if (url.pathname.startsWith('/block-collection/')) {
+      // Links on a different aem.live domain are made relative to current domain.
+      // Restore for block collection links.
+      link.href = `https://main--aem-block-collection--adobe.aem.live${url.pathname}`;
+    }
     link.setAttribute('target', returnLinkTarget(link.href));
   });
 }


### PR DESCRIPTION
Links to block collections (https://main--aem-block-collection--adobe.aem.live/block-collection/headings) are made relative and then are invalid.
This PR is to rebuild the links (works until we use https://www.aem.live/block-collection - not the case today).

Test page: https://block-collection-links--helix-website--adobe.aem.page/developer/block-collection/headings (click on `See Live Output`)