### PR TITLE
Change the Altcha script source URL

### DIFF
--- a/blocks/ue-trial/ue-trial.js
+++ b/blocks/ue-trial/ue-trial.js
@@ -719,7 +719,7 @@ async function buildForm(block) {
   });
   // Try to load Altcha script dynamically
   const altchaScript = createTag('script', {
-    src: 'https://cdn.jsdelivr.net/gh/altcha-org/altcha@main/dist/altcha.min.js',
+    src: 'https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js',
     async: 'true',
     defer: 'true',
     nonce: 'aem',


### PR DESCRIPTION
the old url has a 404 - replaced it with valid URL - better would be selfhosting the file.

## Description

sign-up for https://aem.now is broken because altcha JS can't be loaded - 404 on https://cdn.jsdelivr.net/gh/altcha-org/altcha@main/dist/altcha.min.js . Changed URL that works https://cdn.jsdelivr.net/gh/altcha-org/altcha/dist/altcha.min.js