### PR TITLE
feat(oversight): redirect performance timeline dashboard

### DIFF
--- a/tools/oversight/charts/redirectperf.js
+++ b/tools/oversight/charts/redirectperf.js
@@ -1,0 +1,407 @@
+import {
+  Chart, TimeScale, LinearScale, registerables,
+  // eslint-disable-next-line import/no-unresolved, import/extensions
+} from 'chartjs';
+// eslint-disable-next-line import/no-unresolved, import/extensions
+import 'chartjs-adapter-luxon';
+import AbstractChart from './chart.js';
+import {
+  truncate,
+  cssVariable,
+  INTERPOLATION_THRESHOLD,
+  isDarkTheme,
+} from '../utils.js';
+
+Chart.register(TimeScale, LinearScale, ...registerables);
+
+const REDIRECT_TARGET_RE = /^(\d+)([:~])(\d+)$/;
+
+function parseRedirectTarget(target) {
+  if (typeof target !== 'string') return null;
+  const m = target.match(REDIRECT_TARGET_RE);
+  if (!m) return null;
+  return {
+    count: Number.parseInt(m[1], 10),
+    type: m[2] === '~' ? 'external' : 'internal',
+    duration: Number.parseInt(m[3], 10),
+  };
+}
+
+function findRedirectEvent(bundle) {
+  return bundle.events.find(
+    (e) => e.checkpoint === 'redirect' && typeof e.target === 'string',
+  );
+}
+
+/**
+ * RedirectPerfChart shows redirect duration percentiles over time
+ * as a line chart, with p50 and p75 redirect duration.
+ */
+export default class RedirectPerfChart extends AbstractChart {
+  /**
+   * Returns a function that groups data bundles by time slot,
+   * truncated to the chart's configured granularity.
+   * @returns {function} A grouping function for data bundles
+   */
+  get groupBy() {
+    const groupFn = (bundle) => {
+      const slotTime = new Date(bundle.timeSlot);
+      return truncate(slotTime, this.chartConfig.unit);
+    };
+
+    groupFn.fillerFn = (existing) => {
+      const endDate = this.chartConfig.endDate ? new Date(this.chartConfig.endDate) : new Date();
+
+      let startDate;
+      if (!this.chartConfig.startDate) {
+        startDate = new Date(endDate);
+        if (this.chartConfig.unit === 'day') startDate.setDate(endDate.getDate() - 30);
+        if (this.chartConfig.unit === 'hour') startDate.setDate(endDate.getDate() - 7);
+        if (this.chartConfig.unit === 'week') startDate.setMonth(endDate.getMonth() - 12);
+        if (this.chartConfig.unit === 'month') startDate.setMonth(endDate.getMonth() - 1);
+      } else {
+        startDate = new Date(this.chartConfig.startDate);
+      }
+
+      existing.sort((a, b) => new Date(a) - new Date(b));
+      const slots = new Set(existing);
+      slots.forEach((slot) => {
+        const slotDate = new Date(slot);
+        if (slotDate < startDate || slotDate > endDate) {
+          slots.delete(slot);
+        }
+      });
+      const slotTime = new Date(startDate);
+      let maxSlots = 1000;
+      while (slotTime <= endDate) {
+        const { unit } = this.chartConfig;
+        slots.add(truncate(slotTime, unit));
+        if (this.chartConfig.unit === 'day') slotTime.setDate(slotTime.getDate() + 1);
+        if (this.chartConfig.unit === 'hour') slotTime.setHours(slotTime.getHours() + 1);
+        if (this.chartConfig.unit === 'week') slotTime.setDate(slotTime.getDate() + 7);
+        if (this.chartConfig.unit === 'month') slotTime.setMonth(slotTime.getMonth() + 1);
+        maxSlots -= 1;
+        if (maxSlots < 0) {
+          // eslint-disable-next-line no-console
+          console.error('Too many slots');
+          break;
+        }
+      }
+      return Array.from(slots);
+    };
+
+    return groupFn;
+  }
+
+  render() {
+    if (!this.elems.canvas) return;
+    // eslint-disable-next-line no-undef
+    this.chart = new Chart(this.elems.canvas, {
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [
+          {
+            label: 'Redirect Duration (p50)',
+            backgroundColor: cssVariable('--spectrum-blue-600'),
+            borderColor: cssVariable('--spectrum-blue-600'),
+            tension: 0.2,
+            pointRadius: 2,
+            spanGaps: true,
+            data: [],
+          },
+          {
+            label: 'Redirect Duration (p75)',
+            backgroundColor: cssVariable('--spectrum-blue-400'),
+            borderColor: cssVariable('--spectrum-blue-400'),
+            borderDash: [5, 5],
+            tension: 0.2,
+            pointRadius: 2,
+            spanGaps: true,
+            data: [],
+          },
+        ],
+      },
+      options: {
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: true,
+            labels: {
+              color: isDarkTheme() ? '#b3b3b3' : undefined,
+            },
+          },
+          customCanvasBackgroundColor: {
+            color: isDarkTheme() ? '#1e1e1e' : 'white',
+          },
+          tooltip: {
+            intersect: false,
+            callbacks: {
+              label: (context) => {
+                const value = context.parsed.y;
+                if (value === null || value === undefined || Number.isNaN(value)) return '';
+                return `${context.dataset.label}: ${Math.round(value)}ms`;
+              },
+            },
+          },
+        },
+        interaction: {
+          mode: 'nearest',
+          axis: 'x',
+        },
+        animation: {
+          duration: 300,
+        },
+        responsive: true,
+        scales: {
+          x: {
+            type: 'time',
+            display: true,
+            grid: { display: false },
+            border: { display: false },
+            offset: true,
+            time: {
+              displayFormats: { day: 'EEE, MMM d' },
+              unit: 'day',
+            },
+            ticks: {
+              minRotation: 90,
+              maxRotation: 90,
+              autoSkip: false,
+              color: isDarkTheme() ? '#b3b3b3' : undefined,
+            },
+          },
+          y: {
+            display: true,
+            beginAtZero: true,
+            border: { display: false },
+            title: {
+              display: true,
+              text: 'Duration (ms)',
+              color: isDarkTheme() ? '#b3b3b3' : undefined,
+            },
+            ticks: {
+              color: isDarkTheme() ? '#b3b3b3' : undefined,
+            },
+          },
+        },
+      },
+    });
+  }
+
+  defineSeries() {
+    const { dataChunks } = this;
+
+    dataChunks.addSeries('hasRedirect', (bundle) => (
+      findRedirectEvent(bundle) ? bundle.weight : undefined
+    ));
+    dataChunks.addSeries('noRedirect', (bundle) => (
+      findRedirectEvent(bundle) ? undefined : bundle.weight
+    ));
+
+    dataChunks.addSeries('internalRedirect', (bundle) => {
+      const evt = findRedirectEvent(bundle);
+      if (!evt) return undefined;
+      const parsed = parseRedirectTarget(evt.target);
+      return parsed && parsed.type === 'internal' ? bundle.weight : undefined;
+    });
+    dataChunks.addSeries('externalRedirect', (bundle) => {
+      const evt = findRedirectEvent(bundle);
+      if (!evt) return undefined;
+      const parsed = parseRedirectTarget(evt.target);
+      return parsed && parsed.type === 'external' ? bundle.weight : undefined;
+    });
+
+    // Interpolations for percentage of traffic with/without redirects
+    dataChunks.addInterpolation(
+      'iHasRedirect',
+      ['hasRedirect', 'noRedirect'],
+      ({ hasRedirect, noRedirect }) => {
+        const valueCount = hasRedirect.count + noRedirect.count;
+        if (valueCount < INTERPOLATION_THRESHOLD) return 0;
+        const totalWeight = hasRedirect.weight + noRedirect.weight;
+        const share = hasRedirect.weight / (totalWeight || 1);
+        return Math.round(share * totalWeight);
+      },
+    );
+    dataChunks.addInterpolation(
+      'iNoRedirect',
+      ['hasRedirect', 'noRedirect'],
+      ({ hasRedirect, noRedirect }) => {
+        const valueCount = hasRedirect.count + noRedirect.count;
+        if (valueCount < INTERPOLATION_THRESHOLD) {
+          return hasRedirect.weight + noRedirect.weight;
+        }
+        const totalWeight = hasRedirect.weight + noRedirect.weight;
+        const share = noRedirect.weight / (totalWeight || 1);
+        return Math.round(share * totalWeight);
+      },
+    );
+  }
+
+  /**
+   * Register redirect-specific facets. Called by slicer.js via the
+   * updateDataFacets hook so these are available without needing
+   * checkpoint=redirect in the URL.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  updateDataFacets(dataChunks) {
+    dataChunks.addFacet('redirect.type', (bundle) => Array.from(
+      bundle.events
+        .filter((evt) => evt.checkpoint === 'redirect')
+        .reduce((acc, evt) => {
+          const parsed = parseRedirectTarget(evt.target);
+          if (parsed) acc.add(parsed.type);
+          return acc;
+        }, new Set()),
+    ));
+
+    dataChunks.addFacet('redirect.count', (bundle) => Array.from(
+      bundle.events
+        .filter((evt) => evt.checkpoint === 'redirect')
+        .reduce((acc, evt) => {
+          const parsed = parseRedirectTarget(evt.target);
+          if (parsed) acc.add(String(parsed.count));
+          return acc;
+        }, new Set()),
+    ));
+
+    dataChunks.addFacet('redirect.source', (bundle) => Array.from(
+      bundle.events
+        .filter((evt) => evt.checkpoint === 'redirect')
+        .filter(({ source }) => source)
+        .reduce((acc, { source }) => { acc.add(String(source)); return acc; }, new Set()),
+    ));
+  }
+
+  async draw() {
+    const params = new URL(window.location).searchParams;
+    const view = params.get('view');
+
+    const startDate = params.get('startDate');
+    const endDate = params.get('endDate');
+
+    let customView = 'year';
+    let unit = 'month';
+    let units = 12;
+    if (view === 'custom') {
+      const diff = endDate ? new Date(endDate).getTime() - new Date(startDate).getTime() : 0;
+      if (diff < (1000 * 60 * 60 * 24)) {
+        customView = 'hour';
+        unit = 'hour';
+        units = 24;
+      } else if (diff <= (1000 * 60 * 60 * 24 * 7)) {
+        customView = 'week';
+        unit = 'hour';
+        units = Math.round(diff / (1000 * 60 * 60));
+      } else if (diff <= (1000 * 60 * 60 * 24 * 31)) {
+        customView = 'month';
+        unit = 'day';
+        units = 30;
+      } else if (diff <= (1000 * 60 * 60 * 24 * 365 * 3)) {
+        customView = 'week';
+        unit = 'week';
+        units = Math.round(diff / (1000 * 60 * 60 * 24 * 7));
+      }
+    }
+
+    const focus = params.get('focus');
+
+    if (this.dataChunks.filtered.length < 1000) {
+      this.elems.lowDataWarning.ariaHidden = 'false';
+    } else {
+      this.elems.lowDataWarning.ariaHidden = 'true';
+    }
+
+    const configs = {
+      month: {
+        view, unit: 'day', units: 30, focus, startDate, endDate,
+      },
+      week: {
+        view, unit: 'hour', units: 24 * 7, focus, startDate, endDate,
+      },
+      year: {
+        view, unit: 'week', units: 52, focus, startDate, endDate,
+      },
+      custom: {
+        view: customView, unit, units, focus, startDate, endDate,
+      },
+    };
+
+    const config = configs[view];
+    this.config = { ...config, ...this.config };
+    this.defineSeries();
+
+    // group by date, according to the chart config
+    const group = this.dataChunks.group(this.groupBy);
+    const chartLabels = Object.keys(group).sort();
+
+    const { p50s, p75s } = Object.entries(this.dataChunks.aggregates)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .reduce((acc, [, totals]) => {
+        const p50 = totals.redirectDuration.percentile(50);
+        const p75 = totals.redirectDuration.percentile(75);
+        acc.p50s.push(Number.isFinite(p50) ? p50 : null);
+        acc.p75s.push(Number.isFinite(p75) ? p75 : null);
+        return acc;
+      }, { p50s: [], p75s: [] });
+
+    this.chart.data.datasets[0].data = p50s;
+    this.chart.data.datasets[1].data = p75s;
+    this.chart.data.labels = chartLabels;
+    this.chart.options.scales.x.time.unit = config.unit;
+
+    this.chart.update();
+
+    // Update redirect-specific key metric cards
+    this.updateRedirectMetrics();
+  }
+
+  updateRedirectMetrics() {
+    const { dataChunks } = this;
+
+    const redirectPvs = document.querySelector('#redirect-pvs p number-format');
+    if (redirectPvs) {
+      const sum = dataChunks.totals.hasRedirect
+        ? dataChunks.totals.hasRedirect.sum : 0;
+      const count = dataChunks.totals.hasRedirect
+        ? dataChunks.totals.hasRedirect.count : 0;
+      redirectPvs.textContent = sum;
+      redirectPvs.setAttribute('sample-size', count);
+    }
+
+    const redirectDuration = document.querySelector('#redirect-duration p number-format');
+    if (redirectDuration) {
+      const p50 = dataChunks.totals.redirectDuration
+        ? dataChunks.totals.redirectDuration.percentile(50) : 0;
+      redirectDuration.textContent = Number.isFinite(p50) ? Math.round(p50) : '-';
+    }
+
+    const redirectPct = document.querySelector('#redirect-pct p number-format');
+    if (redirectPct) {
+      const has = dataChunks.totals.hasRedirect
+        ? dataChunks.totals.hasRedirect.sum : 0;
+      const total = dataChunks.totals.pageViews
+        ? dataChunks.totals.pageViews.sum : 0;
+      redirectPct.textContent = total > 0
+        ? Math.round((has / total) * 1000) / 10
+        : '-';
+    }
+  }
+
+  updateColorScheme() {
+    if (!this.chart || !this.chart.update || !this.chart.options) return;
+
+    const isDark = isDarkTheme();
+
+    this.chart.options.plugins.customCanvasBackgroundColor.color = isDark ? '#1e1e1e' : 'white';
+    this.chart.options.scales.x.ticks.color = isDark ? '#b3b3b3' : undefined;
+    this.chart.options.scales.y.ticks.color = isDark ? '#b3b3b3' : undefined;
+    this.chart.options.scales.y.title.color = isDark ? '#b3b3b3' : undefined;
+    if (this.chart.options.plugins.legend) {
+      this.chart.options.plugins.legend.labels.color = isDark ? '#b3b3b3' : undefined;
+    }
+
+    this.chart.update();
+  }
+}

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -423,10 +423,15 @@
             <a href="/docs/optel-explorer#facet-redirect" class="help" target="_blank"
               title="What links of the site are redirecting?"></a>
           </link-facet>
-          <list-facet facet="redirect.target">
+          <list-facet facet="redirect.target" drilldown="redirectperf.html">
             <legend>Redirect Count</legend>
             <a href="/docs/optel-explorer#facet-redirect" class="help" target="_blank"
               title="Number of hops it took to reach the final destination page"></a>
+          </list-facet>
+          <list-facet facet="redirect.type" drilldown="redirectperf.html">
+            <legend>Redirect Type</legend>
+            <a href="/docs/optel-explorer#facet-redirect" class="help" target="_blank"
+              title="Internal redirects (same origin) vs external redirects (cross origin)"></a>
           </list-facet>
 
           <list-facet facet="experiment.source">

--- a/tools/oversight/redirectperf.html
+++ b/tools/oversight/redirectperf.html
@@ -1,0 +1,180 @@
+<html>
+
+<head>
+  <title>Redirect Performance | AEM Live</title>
+  <script type="importmap">{"imports": {
+    "chartjs": "https://esm.sh/chart.js@4.4.8",
+    "chartjs-adapter-luxon": "https://esm.sh/chartjs-adapter-luxon@1.3.1?deps=chart.js@4.4.8",
+    "@adobe/rum-distiller": "https://esm.sh/@adobe/rum-distiller@1.22.2"
+  }}</script>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/scripts.js" type="module"></script>
+  <link rel="stylesheet" href="/styles/styles.css" />
+  <script type="module" defer="false">
+    import RedirectPerfChart from './charts/redirectperf.js';
+    import ConversionTracker from './elements/conversion-tracker.js';
+    import IncognitoCheckbox from './elements/incognito-checkbox.js';
+    import FacetSidebar from './elements/facetsidebar.js';
+    import ListFacet from './elements/list-facet.js';
+    import ThumbnailFacet from './elements/thumbnail-facet.js';
+    import LinkFacet from './elements/link-facet.js';
+    import LiteralFacet from './elements/literal-facet.js';
+    import VitalsFacet from './elements/vitals-facet.js';
+    import URLSelector from './elements/url-selector.js';
+    import NumberFormat from './elements/number-format.js';
+    import DateRangePicker from './elements/daterange-picker.js';
+    window.slicer = {
+      Chart: RedirectPerfChart,
+    };
+    customElements.define('incognito-checkbox', IncognitoCheckbox);
+    customElements.define('facet-sidebar', FacetSidebar);
+    customElements.define('list-facet', ListFacet);
+    customElements.define('thumbnail-facet', ThumbnailFacet);
+    customElements.define('link-facet', LinkFacet);
+    customElements.define('literal-facet', LiteralFacet);
+    customElements.define('vitals-facet', VitalsFacet);
+    customElements.define('url-selector', URLSelector);
+    customElements.define('conversion-tracker', ConversionTracker);
+    customElements.define('number-format', NumberFormat);
+    customElements.define('daterange-picker', DateRangePicker);
+  </script>
+  <script src="./slicer.js" type="module"></script>
+  <link rel="stylesheet" href="./rum-slicer.css">
+  </head>
+
+<body>
+  <header></header>
+  <main>
+    <div>
+        <div id="deepmain">
+          <div class="output">
+            <div class="title">
+              <url-selector>www.aem.live</url-selector>
+              <daterange-picker id="view">
+                <ul hidden>
+                  <li data-value="week">Last week</li>
+                  <li data-value="month" aria-selected="true">Last month</li>
+                  <li data-value="year">Last year</li>
+                  <li data-value="custom">Custom</li>
+                </ul>
+              </daterange-picker>
+              <incognito-checkbox></incognito-checkbox>
+            </div>
+            <div class="key-metrics">
+              <ul>
+                <li id="pageviews" title="Estimate of page views based on RUM data collected and sampling rate">
+                  <h2>Page views</h2>
+                  <p><number-format>0</number-format></p>
+                </li>
+                <li id="visits" title="Page views which were not linked from another page on this site">
+                  <h2>Visits</h2>
+                  <p><number-format>0</number-format></p>
+                </li>
+                <conversion-tracker id="conversions" title="Page views with a user click outside a consent dialog">
+                  <h2>Engagement</h2>
+                  <p><number-format>0</number-format></p>
+                </conversion-tracker>
+                <li id="redirect-pvs" title="Estimated page views that experienced at least one redirect">
+                  <h2>Redirected PVs</h2>
+                  <p><number-format>0</number-format></p>
+                </li>
+                <li id="redirect-duration" title="Median redirect duration (p50) across all redirected page views">
+                  <h2>Redirect Duration (p50)</h2>
+                  <p><number-format precision="0" fuzzy="false">0</number-format><span class="unit">ms</span></p>
+                </li>
+                <li id="redirect-pct" title="Percentage of page views that experienced a redirect">
+                  <h2>% Redirected</h2>
+                  <p><number-format precision="1" fuzzy="false">0</number-format><span class="unit">%</span></p>
+                </li>
+              </ul>
+              <div class="key-metrics-more" aria-hidden="true">
+                <ul>
+                  <li id="lcp" title="Largest Contentful Paint">
+                    <h2>LCP</h2>
+                    <p><number-format precision="2" fuzzy="false">0</number-format></p>
+                  </li>
+                  <li id="cls" title="Cumulative Layout Shift">
+                    <h2>CLS</h2>
+                    <p><number-format precision="2" fuzzy="false">0</number-format></p>
+                  </li>
+                  <li id="inp" title="Interaction to Next Paint">
+                    <h2>INP</h2>
+                    <p><number-format precision="2" fuzzy="false">0</number-format></p>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <figure>
+              <div class="chart-container solitary">
+                <canvas id="time-series"></canvas>
+              </div>
+              <div class="filter-tags"></div>
+              <figcaption>
+                <span aria-hidden="true" id="low-data-warning"><span class="danger-icon"></span> small sample size, accuracy
+                  reduced.</span>
+                <span id="timezone"></span>
+              </figcaption>
+            </figure>
+          </div>
+          <facet-sidebar>
+            <list-facet facet="userAgent" drilldown="share.html">
+              <legend>Device Type and Operating System</legend>
+              <dl>
+                <dt>desktop</dt>
+                <dd>All Desktop</dd>
+                <dt>desktop:windows</dt>
+                <dd>Windows Desktop</dd>
+                <dt>desktop:mac</dt>
+                <dd>Mac Desktop</dd>
+                <dt>desktop:linux</dt>
+                <dd>Linux Desktop</dd>
+                <dt>desktop:chromeos</dt>
+                <dd>Chrome OS Desktop</dd>
+                <dt>mobile</dt>
+                <dd>All Mobile</dd>
+                <dt>mobile:android</dt>
+                <dd>Android Mobile</dd>
+                <dt>mobile:ios</dt>
+                <dd>iOS Mobile</dd>
+                <dt>mobile:ipados</dt>
+                <dd>iPad Mobile</dd>
+                <dt>bot</dt>
+                <dd>All Bots</dd>
+                <dt>bot:seo</dt>
+                <dd>SEO Bot</dd>
+                <dt>bot:search</dt>
+                <dd>Search Engine Crawler</dd>
+                <dt>bot:ads</dt>
+                <dd>Ad Bot</dd>
+                <dt>bot:social</dt>
+                <dd>Social Media Bot</dd>
+              </dl>
+            </list-facet>
+            <list-facet facet="redirect.type">
+              <legend>Redirect Type</legend>
+            </list-facet>
+            <list-facet facet="redirect.count">
+              <legend>Redirect Hops</legend>
+            </list-facet>
+            <link-facet facet="url" thumbnail="false" highlight="filter">
+              <legend>URL</legend>
+            </link-facet>
+            <link-facet facet="redirect.source" thumbnail="false">
+              <legend>Redirect Source</legend>
+            </link-facet>
+        </div>
+    </div>
+    </main>
+  <footer></footer>
+  <div id="copied-toast" class="toast" aria-hidden="true">
+    Rows copied to clipboard, ready to paste into spreadsheet
+  </div>
+  <div id="shared-toast" class="toast" aria-hidden="true">
+    Link copied to clipboard, ready to share
+  </div>
+</body>
+
+</html>

--- a/tools/oversight/slicer.js
+++ b/tools/oversight/slicer.js
@@ -83,6 +83,16 @@ dataChunks.addSeries('contentEngagement', (bundle) => {
   return viewEvents.length;
 });
 
+// Extract redirect duration (ms) from redirect checkpoint target
+// Format: "<count>:<duration>" (internal) or "<estimate>~<duration>" (external)
+dataChunks.addSeries('redirectDuration', (bundle) => {
+  const evt = bundle.events.find((e) => e.checkpoint === 'redirect' && typeof e.target === 'string');
+  if (!evt) return undefined;
+  const m = evt.target.match(/^(\d+)([:~])(\d+)$/);
+  if (!m) return undefined;
+  return Number.parseInt(m[3], 10);
+});
+
 function setDomain(domain, key) {
   DOMAIN = domain;
   loader.domain = domain;
@@ -294,6 +304,42 @@ function updateDataFacets(filterText, params, checkpoint) {
       if (cp === 'enter') {
         dataChunks.addFacet('enter.source', enterSource);
       }
+
+      // special handling for redirect checkpoint: the target is encoded as
+      // "<count>:<duration>" (internal) or "<estimate>~<duration>" (external)
+      // Override the default redirect.target facet to show only the hop count,
+      // and add a redirect.type facet for internal/external.
+      if (cp === 'redirect') {
+        const redirectTargetRe = /^(\d+)([:~])(\d+)$/;
+        // Override redirect.target to show clean hop counts instead of raw values
+        dataChunks.addFacet('redirect.target', (bundle) => Array.from(
+          bundle.events
+            .filter((evt) => evt.checkpoint === 'redirect')
+            .reduce((acc, evt) => {
+              const m = typeof evt.target === 'string' && evt.target.match(redirectTargetRe);
+              if (m) acc.add(m[1]);
+              return acc;
+            }, new Set()),
+        ));
+        dataChunks.addFacet('redirect.count', (bundle) => Array.from(
+          bundle.events
+            .filter((evt) => evt.checkpoint === 'redirect')
+            .reduce((acc, evt) => {
+              const m = typeof evt.target === 'string' && evt.target.match(redirectTargetRe);
+              if (m) acc.add(m[1]);
+              return acc;
+            }, new Set()),
+        ));
+        dataChunks.addFacet('redirect.type', (bundle) => Array.from(
+          bundle.events
+            .filter((evt) => evt.checkpoint === 'redirect')
+            .reduce((acc, evt) => {
+              const m = typeof evt.target === 'string' && evt.target.match(redirectTargetRe);
+              if (m) acc.add(m[2] === '~' ? 'external' : 'internal');
+              return acc;
+            }, new Set()),
+        ));
+      }
     });
 
   if (typeof herochart.updateDataFacets === 'function') {
@@ -304,6 +350,9 @@ function updateDataFacets(filterText, params, checkpoint) {
 function updateFilter(params, filterText) {
   const filter = ([key]) => false // TODO: find a better way to filter out non-facet keys
     || (isKnownFacet(key) && !key.endsWith('~'))
+    // also accept dynamically registered facets (e.g. redirect.type, redirect.count)
+    // exclude 'filter' which has its own special condition below
+    || (key !== 'filter' && key in dataChunks.facetFns && !key.endsWith('~'))
     || (key === 'filter' && filterText.length > 2);
   const transform = ([key, value]) => [key, value];
   dataChunks.filter = parseSearchParams(params, filter, transform);


### PR DESCRIPTION
## Summary

- Add a dedicated **Redirect Performance** timeline page (`redirectperf.html`) showing redirect duration percentiles (p50/p75) over time as a line chart
- Fix the **Redirect Count** facet in explorer.html to show clean hop counts (`1`, `2`, `3`) instead of raw encoded values (`1~53`, `1:54`) introduced in https://github.com/adobe/helix-rum-enhancer/pull/516
- Add a **Redirect Type** facet (internal/external) to both explorer.html and the new redirectperf page
- Enable facet-based filtering on the new page — clicking "internal" or "external" in the Redirect Type facet updates the chart and metrics
- Add drilldown links from explorer Redirect Count and Redirect Type facets to the new redirectperf page

## Details

### New files
- `tools/oversight/redirectperf.html` — Dashboard page with standard + redirect-specific key metric cards, Chart.js time-series chart, and redirect facet sidebar
- `tools/oversight/charts/redirectperf.js` — `RedirectPerfChart` class extending `AbstractChart`, with `groupBy` (time bucketing), `defineSeries` (hasRedirect, noRedirect, internalRedirect, externalRedirect), `updateDataFacets` (redirect.type, redirect.count, redirect.source), and `draw` (p50/p75 redirect duration per time bucket)

### Modified files
- `tools/oversight/slicer.js`:
  - Add `redirectDuration` series (extracts duration in ms from redirect checkpoint target)
  - Add special handling for `cp === 'redirect'` in `updateDataFacets` to override `redirect.target` with clean hop counts and register `redirect.type` / `redirect.count` facets
  - Extend `updateFilter` to accept dynamically registered facets (`key in dataChunks.facetFns`) so that `redirect.type` and `redirect.count` filtering works — `isKnownFacet()` from rum-distiller uses a static suffix list that doesn't include `type` or `count`
- `tools/oversight/explorer.html`:
  - Add `redirect.type` list-facet after existing `redirect.target` facet
  - Add `drilldown="redirectperf.html"` to both redirect facets

### Redirect checkpoint encoding
The `redirect` checkpoint encodes data in the event `target` field:
- `<count>:<duration>` for internal redirects (`:` separator)
- `<estimate>~<duration>` for external redirects (`~` separator)

Regex: `/^(\d+)([:~])(\d+)$/`

## Test plan

Tested with `www.cox.com` (has both internal and external redirects with 1-60+ hops):

- [x] redirectperf.html renders line chart with p50/p75 redirect duration over time
- [x] Key metrics show: Redirected PVs (5m), Median Duration (443ms), % Redirected (30%)
- [x] Redirect Type facet shows "external" (3.6m) and "internal" (1.4m)
- [x] Clicking "internal" filters data: PVs drop to 1.4m, duration to 279ms, visits to 1m
- [x] Clicking "external" filters data: PVs 3.6m, duration 604ms
- [x] Redirect Hops facet shows clean values (1, 2, 3, 4, 5) and filtering works
- [x] Explorer redirect.target facet shows clean hop counts (not raw encoded values)
- [x] Explorer redirect.type facet shows external/internal
- [x] Drilldown arrows on redirect facets navigate to redirectperf.html
- [x] Dark mode theming works
- [x] No regression on cwvperf.html (8908 bundles, 12m visits, no filter issues)
- [x] No console errors

## Screenshots

### Explorer
<img width="1725" height="350" alt="Screenshot 2026-04-15 at 10 43 18" src="https://github.com/user-attachments/assets/d402862c-fc39-4f80-9034-2e5f5d7d0fac" />
<img width="846" height="178" alt="Screenshot 2026-04-15 at 10 43 25" src="https://github.com/user-attachments/assets/0c53b582-8f9f-4e30-9cdb-33e806c401ca" />

### Deep Dive
<img width="1715" height="844" alt="Screenshot 2026-04-15 at 10 43 49" src="https://github.com/user-attachments/assets/3ac8f1ab-cf9b-4cd9-bf89-2a1106ed769e" />
