### PR TITLE
ci: declare empty permissions on log-publish workflow

### DIFF
--- a/.github/workflows/log-publish.yml
+++ b/.github/workflows/log-publish.yml
@@ -1,7 +1,10 @@
-on: 
+on:
   repository_dispatch:
     types:
       - resource-published-native
+
+permissions: {}
+
 jobs:
   print:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `log-publish` workflow triggers on `repository_dispatch` (an elevated-context trigger). Its two jobs (`print`, `slack`) only:

- log fields from `github.event.client_payload`
- run `frabert/replace-string-action`
- post to `slackapi/slack-github-action` via `SLACK_WEBHOOK_URL`

No GitHub API call uses the workflow `GITHUB_TOKEN`. `permissions: {}` at workflow scope captures that contract; the token gets no scopes.

The style matches the workflow-level blocks already declared by `track-publishes.yml` (`actions: read, contents: write` for the cross-run dispatch), `claude.yml`, `claude-code-review.yml`, and `update-importmaps.yml`.

Third-party action exposure that motivates pinning: `frabert/replace-string-action@v2`, `slackapi/slack-github-action@v2.1.1`. With `permissions: {}`, a hypothetical compromise (cf. `tj-actions/changed-files` CVE-2025-30066) inside one of those actions can't touch the repo via the workflow token.

`test.yml` is 24 lines and below the noise floor; left out of this PR.

No behavioural change.