### PR TITLE
fix(video): constrain video block to content column on blog pages

### DIFF
--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -10,3 +10,9 @@
 .video video {
   width: 100%;
 }
+
+body.blog-template .video-wrapper {
+  max-width: var(--blog-content-width, 100%);
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -404,8 +404,12 @@ aside {
     margin-right: 0;
   }
 
+  body.blog-template {
+    --blog-content-width: 70%;
+  }
+
   .blog-template .default-content-wrapper {
-    max-width: 70%;
+    max-width: var(--blog-content-width);
   }
 }
 
@@ -422,8 +426,12 @@ aside {
     max-width: var(--grid-desktop-container-width);
   }
 
+  body.blog-template {
+    --blog-content-width: 60%;
+  }
+
   .blog-template .default-content-wrapper {
-    max-width: 60%;
+    max-width: var(--blog-content-width);
     height: 50%;
   }
 }


### PR DESCRIPTION
## Summary
- The video block was stretching to full browser width on blog pages instead of staying within the blog content column.
- Blog content column width is now defined in one place and reused so the video block (and any future block) stays aligned with the rest of the article content.

Fixes #1076

## Preview
https://video-layout--helix-website--adobe.aem.page/blog/testing-in-aem

## Test plan
- [ ] Verify a `/blog/*` page with a video block — video sits within the centered content column at all breakpoints (mobile, ≥900px, ≥1250px).
- [ ] Verify a non-blog page with a video block still renders full-width as before.
- [ ] Confirm blog article text width is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)