### PR TITLE
fix(doc-search): fix X button, clear results, and FAQ anchor links

### DIFF
--- a/blocks/doc-search/doc-search.css
+++ b/blocks/doc-search/doc-search.css
@@ -9,7 +9,7 @@
 
 .doc-search form {
   margin: 0 auto;
-  padding: 0 12px;
+  padding: 0;
   font: inherit;
 }
 
@@ -32,7 +32,7 @@
   border: 1px solid;
   border-color: var(--border-color-medium);
   border-radius: 4px;
-  padding: 0 0 0 30px;
+  padding: 0 0 0 48px;
   font: inherit;
   font-size: 14px;
   transition: border-color 130ms ease-in-out, box-shadow 130ms ease-in-out;
@@ -58,7 +58,7 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  right: 13px;
+  right: 4px;
   outline: none;
   border: none;
   border-radius: 3px;

--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -265,17 +265,11 @@ function hideResults(container) {
   if (aside) aside.classList.remove('expand');
 }
 
-function getIdFromSectionMetadata(section) {
-  const sectionId = section.parentElement?.querySelector('.section-metadata div div:nth-child(2)')?.textContent;
-  return sectionId;
-}
-
 function createSearchResultObject(doc, terms, source) {
-  const id = getIdFromSectionMetadata(doc);
   return {
     title: doc.querySelector('h3')?.textContent || '',
     description: doc.querySelector('p')?.textContent || '',
-    path: `/docs/faq#${id}` || '',
+    path: doc.id ? `/docs/faq#${doc.id}` : '/docs/faq',
     image: window.faqImage || '/default-meta-image.jpg',
     content: doc.innerHTML,
     terms,

--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -260,6 +260,9 @@ export function displayResults(matches, terms, container, isHomepage) {
  */
 function hideResults(container) {
   container.setAttribute('aria-hidden', true);
+  container.classList.remove('open');
+  const aside = container.closest('aside');
+  if (aside) aside.classList.remove('expand');
 }
 
 function getIdFromSectionMetadata(section) {
@@ -272,7 +275,7 @@ function createSearchResultObject(doc, terms, source) {
   return {
     title: doc.querySelector('h3')?.textContent || '',
     description: doc.querySelector('p')?.textContent || '',
-    path: `/docs/faq#${id}` || '',
+    path: id ? `/docs/faq#${id}` : '/docs/faq',
     image: window.faqImage || '/default-meta-image.jpg',
     content: doc.innerHTML,
     terms,
@@ -576,7 +579,7 @@ export default async function decorate(block) {
 
   // build search bar
   const form = createTag('form');
-  const search = createTag('input', { type: 'search', 'aria-label': 'Search the documentation' });
+  const search = createTag('input', { type: 'search', 'aria-label': 'Search the documentation', placeholder: 'Search the documentation' });
   const clear = createTag('button', { type: 'reset' }, '✕');
   const icon = buildSearchIcon();
   form.append(icon, search, clear);

--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -573,7 +573,13 @@ export default async function decorate(block) {
 
   // build search bar
   const form = createTag('form');
-  const search = createTag('input', { type: 'search', 'aria-label': 'Search the documentation', placeholder: 'Search the documentation' });
+  const search = createTag('input', {
+    type: 'search',
+    'aria-label': 'Search',
+    placeholder: 'Search the documentation',
+    name: 'search',
+  });
+
   const clear = createTag('button', { type: 'reset' }, '✕');
   const icon = buildSearchIcon();
   form.append(icon, search, clear);

--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -265,13 +265,8 @@ function hideResults(container) {
   if (aside) aside.classList.remove('expand');
 }
 
-function getIdFromSectionMetadata(section) {
-  const sectionId = section.parentElement?.querySelector('.section-metadata div div:nth-child(2)')?.textContent;
-  return sectionId;
-}
-
 function createSearchResultObject(doc, terms, source) {
-  const id = doc.querySelector('h3')?.id || getIdFromSectionMetadata(doc);
+  const id = doc.id || doc.querySelector('h3')?.id;
   return {
     title: doc.querySelector('h3')?.textContent || '',
     description: doc.querySelector('p')?.textContent || '',

--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -271,7 +271,7 @@ function getIdFromSectionMetadata(section) {
 }
 
 function createSearchResultObject(doc, terms, source) {
-  const id = getIdFromSectionMetadata(doc);
+  const id = doc.querySelector('h3')?.id || getIdFromSectionMetadata(doc);
   return {
     title: doc.querySelector('h3')?.textContent || '',
     description: doc.querySelector('p')?.textContent || '',

--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -265,12 +265,17 @@ function hideResults(container) {
   if (aside) aside.classList.remove('expand');
 }
 
+function getIdFromSectionMetadata(section) {
+  const sectionId = section.parentElement?.querySelector('.section-metadata div div:nth-child(2)')?.textContent;
+  return sectionId;
+}
+
 function createSearchResultObject(doc, terms, source) {
-  const id = doc.id || doc.querySelector('h3')?.id;
+  const id = getIdFromSectionMetadata(doc);
   return {
     title: doc.querySelector('h3')?.textContent || '',
     description: doc.querySelector('p')?.textContent || '',
-    path: id ? `/docs/faq#${id}` : '/docs/faq',
+    path: `/docs/faq#${id}` || '',
     image: window.faqImage || '/default-meta-image.jpg',
     content: doc.innerHTML,
     terms,

--- a/blocks/side-navigation/side-navigation.css
+++ b/blocks/side-navigation/side-navigation.css
@@ -30,6 +30,11 @@
   display: none;
 }
 
+/* remove doc-search block padding when it sits directly in the aside (mobile) */
+.side-navigation-wrapper > .doc-search {
+  padding: 0;
+}
+
 .side-navigation {
   width: 300px;
   border-radius: 16px;
@@ -53,30 +58,11 @@
   background: light-dark(var(--color-white), #1e1e1e);
 }
 
-.side-navigation.overlay .search-input-wrapper {
-  display: none;
-}
-
-@media screen and (width <= 899px) {
-  .guides-template .without-full-width-hero .search-input-wrapper {
+/* hide desktop search block from mobile overlay */
+@media screen and (width < 900px) {
+  .side-navigation .doc-search {
     display: none;
   }
-}
-
-.side-navigation-wrapper input[type="text"] {
-  width: 100%;
-  border: solid 1px light-dark(lightgray, #505050);
-  padding: var(--spacing-xxs) var(--spacing-xs);
-  box-sizing: border-box;
-  border-radius: 8px;
-  font-family: var(--body-font-family);
-  font-size: var(--type-body-xs-size);
-  background: light-dark(var(--color-white), #2c2c2c);
-  color: light-dark(var(--color-black), #e8e8e8);
-}
-
-.side-navigation-wrapper input[type="text"]::placeholder {
-  color: light-dark(var(--color-gray-700), #8a8a8a);
 }
 
 .side-navigation a {
@@ -338,6 +324,7 @@
   padding: unset;
 }
 
+/* combined header search result styles here for consistency */
 .results-wrapper {
   list-style: none;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
@@ -488,7 +475,8 @@
     align-items: flex-start;
   }
 
-  .side-navigation-wrapper > .search-input-wrapper {
+  /* hide mobile search block on desktop — it lives inside the sidebar there */
+  .side-navigation-wrapper > .doc-search {
     display: none;
   }
 

--- a/blocks/side-navigation/side-navigation.js
+++ b/blocks/side-navigation/side-navigation.js
@@ -49,29 +49,35 @@ export default async function decorate(block) {
   const backBtnInner = '<button class="back-btn">Back</button>';
   const backBtn = createTag('div', { class: 'side-navigation-overlay-btn-wrapper' }, backBtnInner);
 
-  const searchInputInner = '<input type="text" name="search" placeholder="Search...">';
-  const searchInput = createTag('div', { class: 'search-input-wrapper' }, searchInputInner);
-  const searchInputOuter = searchInput.cloneNode(true);
+  const skipLink = createTag('a', { class: 'skip-link', href: '#search-results' }, 'Skip to results');
+
+  // Desktop: doc-search inside side-nav overlay, results expand alongside nav (hidden on mobile)
   const resultsContainer = createTag('div', { class: 'results-wrapper', id: 'search-results' });
   aside.append(resultsContainer);
-
-  const skipLink = createTag('a', { class: 'skip-link', href: '#search-results' }, 'Skip to results');
   const searchBlock = buildBlock('doc-search', [[
     '<a href="/docpages-index.json">Search</a>',
     '<a href="/docs/faq">FAQ</a>',
   ]]);
   searchBlock.dataset.resultsContainerClass = 'results-wrapper';
-  aside.prepend(docButton);
-  aside.prepend(searchInputOuter);
-  block.prepend(skipLink);
 
+  // Mobile: doc-search directly in aside, shares results-wrapper with desktop block
+  const mobileSearchBlock = buildBlock('doc-search', [[
+    '<a href="/docpages-index.json">Search</a>',
+    '<a href="/docs/faq">FAQ</a>',
+  ]]);
+  mobileSearchBlock.dataset.resultsContainerClass = 'results-wrapper';
+
+  aside.prepend(docButton);
+  aside.prepend(mobileSearchBlock);
+
+  block.prepend(skipLink);
   block.prepend(backBtn);
-  // block.prepend(searchInput);
   block.prepend(searchBlock);
+
+  decorateBlock(mobileSearchBlock);
+  await loadBlock(mobileSearchBlock);
   decorateBlock(searchBlock);
   await loadBlock(searchBlock);
-
-  // loadSearch([searchInput, searchInputOuter], resultsContainer);
   // add backdrop overlay
   const backdropCurtain = createTag('div', { class: 'side-navigation-curtain' }, '');
   aside.append(backdropCurtain);


### PR DESCRIPTION
## Summary

- **X button on empty input**: The search input was created without a \`placeholder\` attribute, so \`:placeholder-shown\` was always false, causing the CSS rule \`:not(:placeholder-shown)\` to show the clear button immediately on page load even with no content
- **Clearing search doesn't reset results**: \`hideResults\` only set \`aria-hidden\` but \`.results-wrapper\` visibility is controlled by the \`open\` CSS class — neither \`open\` nor the aside \`expand\` class were removed on clear, leaving results visible
- **FAQ links use wrong anchor strategy**: \`getIdFromSectionMetadata\` relied on finding a \`.section-metadata\` block in the DOM, but section metadata is now processed server-side and the id is already set directly on the parent \`<div>\` element. Use \`doc.id\` directly; fall back to \`/docs/faq\` if no id is present

## Preview

https://search-fixes--helix-website--adobe.aem.page/docs/

## Test plan

- [x] Load \`/docs/\` — confirm no X button visible in empty search box
- [x] Type a search term, then click X — confirm results container closes
- [x] Search for a FAQ-related term — confirm result links go to \`/docs/faq#<id>\` (e.g. \`/docs/faq#fast\`), not \`/docs/faq#undefined\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)