### PR TITLE
feat(blog): video placeholder support and blog layout improvements

### DIFF
--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -5,6 +5,7 @@
 
 .video {
   margin: 32px 0;
+  width: 100%;
 }
 
 .video video {
@@ -12,7 +13,68 @@
 }
 
 body.blog-template .video-wrapper {
-  max-width: var(--blog-content-width, 100%);
+  max-width: var(--blog-content-width, var(--grid-mobile-container-width, 88%));
   margin-left: auto;
   margin-right: auto;
 }
+
+.video .vid-wrapper {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.video .vid-placeholder {
+  position: relative;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.video .vid-placeholder picture {
+  width: 100%;
+}
+
+.video .vid-placeholder picture img {
+  width: 100%;
+  min-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 8px;
+  border: 1px solid rgb(0 0 0 / 10%);
+}
+
+.video .vid-play-btn {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  border: none;
+  background: rgb(0 0 0 / 60%);
+  cursor: pointer;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.video .vid-play-btn::after {
+  content: '';
+  display: block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 14px 0 14px 24px;
+  border-color: transparent transparent transparent white;
+  margin-left: 4px;
+}
+
+.video .vid-play-btn:hover {
+  background: rgb(0 0 0 / 80%);
+}
+

--- a/blocks/video/video.js
+++ b/blocks/video/video.js
@@ -18,8 +18,48 @@ function decorateVideoBlock($block, videoURL) {
   }
 }
 
+function decorateVideoWithPoster($block, videoURL, $picture) {
+  $block.innerHTML = '';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'vid-wrapper vid-placeholder';
+  wrapper.append($picture);
+
+  const playBtn = document.createElement('button');
+  playBtn.className = 'vid-play-btn';
+  playBtn.setAttribute('aria-label', 'Play video');
+  wrapper.append(playBtn);
+
+  const img = $picture.querySelector('img');
+  const posterSrc = img.src;
+  const handleClick = () => {
+    wrapper.removeEventListener('click', handleClick);
+    wrapper.classList.remove('vid-placeholder');
+    wrapper.style.aspectRatio = `${img.clientWidth} / ${img.clientHeight}`;
+    let attrs = 'playsinline controls autoplay';
+    if ($block.classList.contains('autoplay')) attrs = 'playsinline controls muted autoplay loop';
+    wrapper.innerHTML = `<video ${attrs} name="media" poster="${posterSrc}" style="width:100%;height:100%"><source src="${videoURL}" type="video/mp4"></video>`;
+    const video = wrapper.querySelector('video');
+    video.addEventListener('loadedmetadata', () => {
+      wrapper.style.aspectRatio = '';
+      video.style.height = '';
+    }, { once: true });
+    video.addEventListener('play', (e) => {
+      sampleRUM('play', { source: e.target.currentSrc });
+    });
+  };
+  wrapper.addEventListener('click', handleClick);
+
+  $block.append(wrapper);
+}
+
 export default function decorate($block) {
   const $a = $block.querySelector('a');
   const videoURL = $a.href;
-  decorateVideoBlock($block, videoURL);
+  const $picture = $block.querySelector('picture');
+
+  if ($picture && videoURL.endsWith('.mp4')) {
+    decorateVideoWithPoster($block, videoURL, $picture);
+  } else {
+    decorateVideoBlock($block, videoURL);
+  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1883,6 +1883,15 @@ body.skills-template main h2 {
   padding-top: var(--spacing-xs);
 }
 
+body.blog-template main h2 {
+  font-size: var(--type-heading-xl-size);
+  line-height: var(--type-heading-xl-lh);
+}
+
+body.blog-template main h2:first-of-type {
+  padding-bottom: 20px;
+}
+
 body.guides-template main p,
 body.guides-template main li,
 body.guides-template main a,


### PR DESCRIPTION
## Summary
- Video block now supports an optional poster image as a clickable placeholder with play button overlay
- Smooth transition from placeholder to video playback using native `poster` attribute (no layout shift)
- Blog `h2` uses `--type-heading-xl-size` to differentiate from `h1`
- Added padding below first `h2` in blog posts
- Video block respects content container width on mobile (below 900px)

## Test plan
- [ ] Verify video placeholder displays correctly on `/docs/optel-explorer`
- [ ] Click play button — video should start without layout shift
- [ ] Pause video — should not restart
- [ ] Check responsive behavior below 900px — video and placeholder should follow content padding
- [ ] Verify video blocks without a placeholder image still work as before
- [ ] Confirm blog h2 is visually smaller than h1

Preview: https://blog-layout--helix-website--adobe.aem.page/docs/optel-explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)