### PR TITLE
fix(styles): scope default-content-wrapper margin reset to guides headings

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -2044,7 +2044,7 @@ main {
   margin-top: 0;
 }
 
-body.guides-template main .default-content-wrapper > :first-of-type:not(.guides-back-btn) {
+body.guides-template main .default-content-wrapper > :is(h1, h2, h3, h4, h5, h6):first-of-type {
   margin-top: 0;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -2040,8 +2040,11 @@ body.skills-template .columns ol {
 }
 
 body.guides-template,
-main,
-.default-content-wrapper > :first-of-type:not(.guides-back-btn) {
+main {
+  margin-top: 0;
+}
+
+body.guides-template main .default-content-wrapper > :first-of-type:not(.guides-back-btn) {
   margin-top: 0;
 }
 


### PR DESCRIPTION
## Summary
- The `.default-content-wrapper > :first-of-type` CSS rule is problematic on `guides-template` pages using the new `github-code` block (or any block that splits default content into a new wrapper), causing the following paragraph to lose its top margin (e.g. https://main--helix-website--adobe.aem.page/examples/how-to-implement-search#filtering-logic)
- The change here scopes the reset to heading elements (`h1`–`h6`) only and removes the now-unneeded `:not(.guides-back-btn)` exclusion.

## Test URLs
Before: https://main--helix-website--adobe.aem.page/examples/how-to-implement-search#filtering-logic
After: https://fix-default-content-wrapper-margin-scope--helix-website--adobe.aem.page/examples/how-to-implement-search#filtering-logic

## Test plan
- [x] `npm run lint` passes
- [x] Verified locally with Playwright against `/examples/how-to-implement-search` (a `guides-template` page): the "Fetching Strategy" and "Filtering Logic" paragraphs now both compute to a consistent `16px` margin-top (previously `16px` vs `0px`)
- [x] Confirmed no regression to the back-button/H1 layout on the same page
- [ ] Review on preview: https://fix-default-content-wrapper-margin-scope--helix-website--adobe.aem.page/examples/how-to-implement-search