### PR TITLE
fix: fall back to youtube feed key when archive is absent

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -877,7 +877,8 @@ export function loadFeedData() {
   fetch(`/community-feeds.json?offset=${offset}`)
     .then((response) => response.json())
     .then((responseJson) => {
-      window.siteindex.archive.data = responseJson?.archive?.data;
+      window.siteindex.archive.data = (responseJson.archive && responseJson.archive.data)
+        ?? (responseJson.youtube && responseJson.youtube.data);
       window.siteindex.loaded = true;
       const event = new Event('dataset-ready');
       document.dispatchEvent(event);


### PR DESCRIPTION
## Description

Production's `/community-feeds.json` nests recordings under `youtube`, not `archive`. `loadFeedData()` only checked `archive`, so the feed came back empty. Now it falls back to `youtube` if `archive` isn't there.

## How Has This Been Tested?

- Before: https://main--aem-website--adobe.aem.live/community
- After: https://feed-fallback--aem-website--adobe.aem.live/community

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
