### PR TITLE
fix(feed): handle both date formats in recent recordings feed

### DIFF
--- a/blocks/feed/feed.js
+++ b/blocks/feed/feed.js
@@ -79,9 +79,16 @@ function getYouTubeId(url) {
   }
 }
 
+function parseFeedDate(serial) {
+  // Excel-style serial (archive sheet) vs. literal timestamp string (youtube sheet)
+  const isSerial = /^\d+(\.\d+)?$/.test(String(serial).trim());
+  return isSerial
+    ? new Date(new Date(1899, 11, 30).getTime() + parseFloat(serial) * 86400000)
+    : new Date(serial.replace(' ', 'T'));
+}
+
 function formatFeedDate(serial) {
-  const epoch = new Date(1899, 11, 30);
-  const d = new Date(epoch.getTime() + parseFloat(serial) * 86400000);
+  const d = parseFeedDate(serial);
   const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
   return `${months[d.getMonth()]} ${d.getFullYear()}`;
 }
@@ -122,7 +129,7 @@ export async function renderFeedCompact(block) {
   }
 
   const data = [...(window.siteindex?.archive?.data || [])]
-    .sort((a, b) => parseFloat(b.Date) - parseFloat(a.Date));
+    .sort((a, b) => parseFeedDate(b.Date) - parseFeedDate(a.Date));
 
   block.textContent = '';
 


### PR DESCRIPTION
## Description

Fixes #1088.

The Recent Recordings feed on `/community` showed "Jul 1905" on every card, with incorrect sort order underneath.

`community-feeds.json` has two sheets with different `Date` formats:
- The older `archive` sheet (Google Sheets-era) stores dates as Excel-style serial numbers, e.g. `"45266.70454861111"`.
- The newer `youtube` sheet (authored in Document Authoring) stores dates as literal timestamp text, e.g. `"2023-12-06 16:54:33"`.

`formatFeedDate()` and the sort comparator in `renderFeedCompact()` only ever handled the serial-number format. `parseFloat("2023-12-06 16:54:33")` reads only the leading digits and returns `2023`, which the code then treated as "2023 days after 1899-12-30" — landing in mid-1905, for every row sourced from the `youtube` sheet.

## Fix

Added `parseFeedDate()`, which detects which format a value is in before parsing it, and used it in both `formatFeedDate()` and the sort comparator so both schemas resolve to correct dates and correct ordering.

## How Has This Been Tested?

- Verified locally against `drafts/rnagy/community-test.plain.html` (using the `feed compact categorized` block) — recordings render with correct, varied dates against the `archive`-keyed local data, no regression.
- Directly tested `formatFeedDate()` against real production-shaped `youtube` date strings (e.g. `"2023-12-06 16:54:33"` → `Dec 2023`) and confirmed correct output.
- `npm run lint` passes clean.

Preview: https://fix-feed-date-format--helix-website--adobe.aem.page/community