### PR TITLE
chore: swap lib-franklin references

### DIFF
--- a/404.html
+++ b/404.html
@@ -32,7 +32,7 @@
     });
   </script>
   <script nonce="aem" type="module">
-    import { sampleRUM } from '/scripts/lib-franklin.js';
+    import { sampleRUM } from '/scripts/aem.js';
     import { applyRedirects } from '/scripts/redirects.js';
     await applyRedirects();
     sampleRUM('404', { source: document.referrer });

--- a/head.html
+++ b/head.html
@@ -5,7 +5,7 @@
   move-to-http-header="true"
 >
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script nonce="aem" src="/scripts/lib-franklin.js" type="module"></script>
+<script nonce="aem" src="/scripts/aem.js" type="module"></script>
 <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
 <script nonce="aem" src="/scripts/indexing-test.js?date=2024-08-16" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>

--- a/tools/oversight/cwvperf.html
+++ b/tools/oversight/cwvperf.html
@@ -9,7 +9,7 @@
   }}</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script type="module" defer="false">

--- a/tools/oversight/explorer.html
+++ b/tools/oversight/explorer.html
@@ -23,7 +23,7 @@
   }}</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script type="module" defer="false">

--- a/tools/oversight/flow.html
+++ b/tools/oversight/flow.html
@@ -9,7 +9,7 @@
   }}</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script type="module" defer="false">

--- a/tools/oversight/list.html
+++ b/tools/oversight/list.html
@@ -8,7 +8,7 @@
   }}</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script type="module" defer="false">

--- a/tools/oversight/share.html
+++ b/tools/oversight/share.html
@@ -9,7 +9,7 @@
   }}</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script type="module" defer="false">

--- a/tools/oversight/single.html
+++ b/tools/oversight/single.html
@@ -9,7 +9,7 @@
   }}</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script type="module" defer="false">

--- a/tools/rum/admin/orgs.html
+++ b/tools/rum/admin/orgs.html
@@ -3,7 +3,7 @@
 <head>
   <title>RUM Admin | Orgs | AEM Live</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script src="./orgs.js" type="module"></script>

--- a/tools/rum/explorer.html
+++ b/tools/rum/explorer.html
@@ -23,7 +23,7 @@
   }}</script>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="robots" content="noindex, nofollow" />
-  <script src="/scripts/lib-franklin.js" type="module"></script>
+  <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css" />
   <script type="module" defer="false">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix broken references to `/scripts/lib-franklin.js`, a file that no longer exists in this repo (superseded by `/scripts/aem.js`).

## How Has This Been Tested?

https://lib-swap--aem-website--adobe.aem.live/

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
