### PR TITLE
fix(ci): point Track Publishes at the Helix 6 admin API and the right site

### DIFF
--- a/.github/admin-token.md
+++ b/.github/admin-token.md
@@ -13,10 +13,25 @@ The steps below take about two minutes. Everything happens against
 `org=adobe`, `site=aem-website` — note that the site is *not* named after this GitHub repo;
 see the site alias warning in `CLAUDE.md`.
 
+## 0. Check you have the `admin` role
+
+API keys can only be minted by a request that already holds the `admin` role on
+`adobe`, and that is a different, higher bar than being able to publish. If you can preview
+and publish the site, or even read its config, that is *not* enough. A mint attempt without
+it fails with:
+
+```
+HTTP/2 403
+x-error: [admin] not authorized
+```
+
+Role mapping for this site lives in the org config (`adobe`), not the site config — the
+site's own `access` block is empty — so ask whoever administers the `adobe` org to grant it,
+or to mint the key for you with the request in step 2.
+
 ## 1. Get a browser auth token
 
-API keys can only be minted by a request that is already authenticated with the `admin`
-role, so start from a normal browser login.
+Start from a normal browser login.
 
 1. Open <https://api.aem.live/auth/adobe> and sign in. (For the full list of identity
    providers, open <https://api.aem.live/login> and pick one.)
@@ -30,8 +45,9 @@ makes to `api.aem.live` — grab it from the **Network** tab instead.
 export AUTH_TOKEN='<the auth_token cookie value>'
 ```
 
-Check it worked. This prints your email and the token's remaining lifetime in seconds —
-it is short-lived, which is exactly why it is not what goes into the repository secret:
+Check it worked. This prints your email and the token's remaining lifetime in seconds
+(about a day) — short-lived, which is exactly why it is not what goes into the repository
+secret:
 
 ```sh
 curl -s https://api.aem.live/profile -H "cookie: auth_token=$AUTH_TOKEN"
@@ -65,8 +81,10 @@ curl -s -o /dev/null -w '%{http_code}\n' \
   -H "authorization: token $API_KEY"
 ```
 
-`200` means you are done. If it returns `403`, the `publish` role was not enough: delete
-the key and mint a new one with `"roles":["admin"]`.
+`200` means you are done. If it returns `403`, the roles you asked for were not enough:
+delete the key and mint a new one with a broader set. The chapter sync in
+`tools/youtube-chapters/` additionally writes to `/{org}/sites/{site}/source/{path}`, so
+check that too if you are minting one key for both workflows.
 
 ```sh
 # only if you need to start over

--- a/.github/admin-token.md
+++ b/.github/admin-token.md
@@ -1,0 +1,93 @@
+# Rotating `AEM_LIVE_ADMIN_TOKEN`
+
+`AEM_LIVE_ADMIN_TOKEN` is the admin API key the workflows in this directory use to talk to
+the AEM Admin API at `https://api.aem.live`. **Track Publishes** reads the publish log with
+it every five minutes and dispatches the events that **Log Publish** turns into Slack
+notifications.
+
+Admin API keys are JWTs and expire — the default is a year. When the key lapses every run
+fails with a `401`, and publish notifications stop silently, so **Track Publishes** checks
+the expiry up front and warns a week ahead.
+
+The steps below take about two minutes. Everything happens against
+`org=adobe`, `site=aem-website` — note that the site is *not* named after this GitHub repo;
+see the site alias warning in `CLAUDE.md`.
+
+## 1. Get a browser auth token
+
+API keys can only be minted by a request that is already authenticated with the `admin`
+role, so start from a normal browser login.
+
+1. Open <https://api.aem.live/auth/adobe> and sign in. (For the full list of identity
+   providers, open <https://api.aem.live/login> and pick one.)
+2. Once you land back on `api.aem.live`, open DevTools → **Application** → **Cookies** →
+   `https://api.aem.live` and copy the value of the `auth_token` cookie.
+
+If you already have the sidekick open on the site, the same token is on any request it
+makes to `api.aem.live` — grab it from the **Network** tab instead.
+
+```sh
+export AUTH_TOKEN='<the auth_token cookie value>'
+```
+
+Check it worked. This prints your email and the token's remaining lifetime in seconds —
+it is short-lived, which is exactly why it is not what goes into the repository secret:
+
+```sh
+curl -s https://api.aem.live/profile -H "cookie: auth_token=$AUTH_TOKEN"
+```
+
+## 2. Mint the API key
+
+```sh
+curl -s -X POST \
+  https://api.aem.live/adobe/sites/aem-website/config/apiKeys.json \
+  -H "cookie: auth_token=$AUTH_TOKEN" \
+  -H 'content-type: application/json' \
+  -d '{"description":"GitHub Actions - track publishes","roles":["publish"]}'
+```
+
+The response's `value` is the key. **It is never stored by the service and cannot be
+retrieved again** — copy it now.
+
+```sh
+export API_KEY='<the value from the response>'
+```
+
+## 3. Check the key actually works
+
+The role a given endpoint needs is not documented yet, so verify rather than assume. This
+is the exact call **Track Publishes** makes:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' \
+  "https://api.aem.live/adobe/sites/aem-website/log?since=15m" \
+  -H "authorization: token $API_KEY"
+```
+
+`200` means you are done. If it returns `403`, the `publish` role was not enough: delete
+the key and mint a new one with `"roles":["admin"]`.
+
+```sh
+# only if you need to start over
+curl -s -X DELETE \
+  https://api.aem.live/adobe/sites/aem-website/config/apiKeys/<id>.json \
+  -H "cookie: auth_token=$AUTH_TOKEN"
+```
+
+## 4. Store it
+
+Settings → Secrets and variables → Actions → `AEM_LIVE_ADMIN_TOKEN` → **Update secret**.
+
+Then run **Track Publishes** manually from the Actions tab and confirm it goes green.
+
+## Listing and cleaning up keys
+
+Listing returns metadata only, never the key itself, so it is safe to run any time:
+
+```sh
+curl -s https://api.aem.live/adobe/sites/aem-website/config/apiKeys.json \
+  -H "cookie: auth_token=$AUTH_TOKEN"
+```
+
+Delete keys you have replaced — a key stays valid until its expiry or until it is deleted.

--- a/.github/admin-token.md
+++ b/.github/admin-token.md
@@ -70,7 +70,35 @@ retrieved again** — copy it now.
 export API_KEY='<the value from the response>'
 ```
 
-## 3. Check the key actually works
+## 3. Enable the key on the site
+
+**A new key does not work until its id is on the site's allow-list**, despite what
+[the API key docs](https://www.aem.live/docs/admin-apikeys) say about keys being enabled
+automatically. Until you do this every call returns:
+
+```
+HTTP/2 401
+x-error: [AWS] Unauthorized
+```
+
+Read the current allow-list, append the `id` the mint returned — do not replace the list,
+other keys depend on it — and post it back:
+
+```sh
+curl -s https://api.aem.live/adobe/sites/aem-website/config/access/admin.json \
+  -H "cookie: auth_token=$AUTH_TOKEN" > access-admin.json
+
+# add the new id to the apiKeyId array in access-admin.json, then:
+curl -s -X POST \
+  https://api.aem.live/adobe/sites/aem-website/config/access/admin.json \
+  -H "cookie: auth_token=$AUTH_TOKEN" \
+  -H 'content-type: application/json' \
+  --data-binary @access-admin.json
+```
+
+Re-read it afterwards and check that `requireAuth` and the `role` block came back unchanged.
+
+## 4. Check the key actually works
 
 The role a given endpoint needs is not documented yet, so verify rather than assume. This
 is the exact call **Track Publishes** makes:
@@ -81,10 +109,15 @@ curl -s -o /dev/null -w '%{http_code}\n' \
   -H "authorization: token $API_KEY"
 ```
 
-`200` means you are done. If it returns `403`, the roles you asked for were not enough:
-delete the key and mint a new one with a broader set. The chapter sync in
-`tools/youtube-chapters/` additionally writes to `/{org}/sites/{site}/source/{path}`, so
-check that too if you are minting one key for both workflows.
+`200` means you are done. `401` means step 3 has not taken effect. `403` means the roles
+you asked for were not enough — delete the key and mint a new one with a broader set.
+
+The chapter sync in `tools/youtube-chapters/` also writes to
+`/{org}/sites/{site}/source/{path}`, so if one key serves both workflows, check that the
+key can `PUT` a scratch document and `DELETE` it again.
+
+A key minted this way is deliberately *not* able to manage configuration — a `POST` to any
+`config/` path returns `403 [admin] not authorized`, so it cannot widen its own access.
 
 ```sh
 # only if you need to start over
@@ -93,7 +126,10 @@ curl -s -X DELETE \
   -H "cookie: auth_token=$AUTH_TOKEN"
 ```
 
-## 4. Store it
+Note that key ids may contain `/`, which the config stores as `_`. Use the id exactly as
+the listing shows it, not the raw `jti` from the mint response, or the delete returns `400`.
+
+## 5. Store it
 
 Settings → Secrets and variables → Actions → `AEM_LIVE_ADMIN_TOKEN` → **Update secret**.
 

--- a/.github/workflows/track-publishes.yml
+++ b/.github/workflows/track-publishes.yml
@@ -14,51 +14,69 @@ env:
   REPOSITORY_DISPATCH_EVENT: "resource-published-native" # default value for all triggers, this is a compatibility fix for older workflows
   WORKFLOW_CALL_USE: "example" # if REPOSITORY_DISPATCH_EVENT is unset, this is the workflow file that will be called
   ROUTE_FILTER: "live" # filter for the route field in the logs, can be 'live' or 'preview'
+  AEM_API: "https://api.aem.live" # Helix 6 admin API; replaces admin.hlx.page
+  AEM_ORG: "adobe"
+  # The GitHub repo is helix-website, but the site serving www.aem.live - and therefore the
+  # one publishes are logged against - is registered as aem-website. See CLAUDE.md.
+  AEM_SITE: "aem-website"
 
 jobs:
   check-token-expiry:
     runs-on: ubuntu-latest
     steps:
       - name: Check JWT token expiration
+        env:
+          TOKEN: ${{ secrets.AEM_LIVE_ADMIN_TOKEN }}
         run: |
-          # Function to decode JWT token part
+          set -euo pipefail
+
+          RUNBOOK="https://github.com/${{ github.repository }}/blob/main/.github/admin-token.md"
+
+          if [[ -z "$TOKEN" ]]; then
+            echo "::error::The AEM_LIVE_ADMIN_TOKEN secret is not configured. See $RUNBOOK"
+            exit 1
+          fi
+
+          # Admin API keys are JWTs, so the expiry can be read without calling the API.
           decode_base64_url() {
-            local len=$((${#1} % 4))
             local result="$1"
-            if [ $len -eq 2 ]; then result="$1"'=='
-            elif [ $len -eq 3 ]; then result="$1"'='
-            fi
+            case $((${#1} % 4)) in
+              2) result="$1==" ;;
+              3) result="$1=" ;;
+            esac
             echo "$result" | tr '_-' '/+' | base64 -d
           }
-          
-          # Get the token
-          TOKEN="${{ secrets.AEM_LIVE_ADMIN_TOKEN }}"
-          
-          # Extract the payload (second part of the JWT)
-          PAYLOAD=$(echo -n $TOKEN | cut -d '.' -f 2)
-          
-          # Decode the payload
-          DECODED_PAYLOAD=$(decode_base64_url $PAYLOAD)
-          
-          # Extract expiration timestamp
-          EXPIRY=$(echo $DECODED_PAYLOAD | jq -r .exp)
+
+          PAYLOAD=$(printf '%s' "$TOKEN" | cut -d '.' -f 2)
+          EXPIRY=$(decode_base64_url "$PAYLOAD" 2>/dev/null | jq -r '.exp // empty' 2>/dev/null || true)
+
+          if [[ -z "$EXPIRY" ]]; then
+            echo "::error::AEM_LIVE_ADMIN_TOKEN is not a JWT with an exp claim. Mint an admin API key as described in $RUNBOOK"
+            exit 1
+          fi
+
           CURRENT_TIME=$(date +%s)
           ONE_WEEK_FROM_NOW=$((CURRENT_TIME + 7*24*60*60))
-          
-          echo "Token expires at: $(date -d @$EXPIRY)"
-          echo "Current time: $(date -d @$CURRENT_TIME)"
-          echo "One week from now: $(date -d @$ONE_WEEK_FROM_NOW)"
-          
-          if [ $EXPIRY -lt $ONE_WEEK_FROM_NOW ]; then
-            echo "::warning::AEM_LIVE_ADMIN_TOKEN will expire in less than a week (on $(date -d @$EXPIRY)). Please renew the token soon."
-            echo "Token expiration is approaching" >> $GITHUB_STEP_SUMMARY
-            echo "The AEM_LIVE_ADMIN_TOKEN will expire on $(date -d @$EXPIRY)" >> $GITHUB_STEP_SUMMARY
-            echo "Please generate a new token and update the repository secret." >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          if [ $EXPIRY -lt $CURRENT_TIME ]; then
-            echo "::error::AEM_LIVE_ADMIN_TOKEN has expired on $(date -d @$EXPIRY)"
+
+          echo "Token expires at: $(date -d "@$EXPIRY")"
+          echo "Current time:     $(date -d "@$CURRENT_TIME")"
+
+          if [[ "$EXPIRY" -lt "$CURRENT_TIME" ]]; then
+            {
+              echo "### AEM_LIVE_ADMIN_TOKEN has expired"
+              echo "It expired on $(date -d "@$EXPIRY"). Every run of this workflow will fail with a 401 until it is rotated."
+              echo "Rotate it by following $RUNBOOK"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::AEM_LIVE_ADMIN_TOKEN expired on $(date -d "@$EXPIRY"). Rotate it: $RUNBOOK"
             exit 1
+          fi
+
+          if [[ "$EXPIRY" -lt "$ONE_WEEK_FROM_NOW" ]]; then
+            {
+              echo "### AEM_LIVE_ADMIN_TOKEN expires soon"
+              echo "It expires on $(date -d "@$EXPIRY"). Rotate it by following $RUNBOOK"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::AEM_LIVE_ADMIN_TOKEN expires on $(date -d "@$EXPIRY"). Rotate it: $RUNBOOK"
           fi
   check-last-run:
     runs-on: ubuntu-latest
@@ -191,7 +209,7 @@ jobs:
       - name: Check for required secrets
         run: |
           if [[ -z "${{ secrets.AEM_LIVE_ADMIN_TOKEN }}" ]]; then
-            echo "::error::The AEM_LIVE_ADMIN_TOKEN secret is not configured. Please add this secret to your repository settings."
+            echo "::error::The AEM_LIVE_ADMIN_TOKEN secret is not configured. See https://github.com/${{ github.repository }}/blob/main/.github/admin-token.md"
             exit 1
           fi
       - name: Get Logs
@@ -204,7 +222,7 @@ jobs:
           echo "Debug: URL encoded from parameter: $FROM_PARAM"
           
           # Construct and echo the full URL for debugging
-          FULL_URL="https://admin.hlx.page/log/adobe/helix-website/main?from=$FROM_PARAM"
+          FULL_URL="${{ env.AEM_API }}/${{ env.AEM_ORG }}/sites/${{ env.AEM_SITE }}/log?from=$FROM_PARAM"
           echo "Debug: Full URL: $FULL_URL"
           
           # Make the API request


### PR DESCRIPTION
## Summary

**Track Publishes has failed on every single run since 18 Feb 2026.** `AEM_LIVE_ADMIN_TOKEN` expired that day, the log request has returned `401` ever since, and the Slack publish notifications driven off it have been silent for six months.

Rotating the token is the actual fix and only a maintainer can do it, so this PR adds the runbook for it and repairs the three things that were broken around it.

## Test Plan

Preview link (workflow-only change, no content or code affected): https://fix-track-publishes--helix-website--adobe.aem.page/

> The PSI check scores that link, which resolves to the stale `helix-website` alias — nothing in this PR affects any page, so a red score there reflects that alias, not this change.

**The secret has been rotated** — `AEM_LIVE_ADMIN_TOKEN` now holds a fresh admin API key for `adobe/aem-website`, scoped `publish` + `author`, valid until 2027-08-31. The runbook in `.github/admin-token.md` records how it was minted.

The new key proves out this PR's change exactly. Same 15-minute window, same key:

| call | result |
| --- | --- |
| `admin.hlx.page/log/adobe/helix-website/main` — what `main` does today | `401 [admin] not authenticated` |
| `api.aem.live/adobe/sites/aem-website/log` — what this PR does | `200`, entries returned |

So `main` still fails even with a valid secret; this PR is the remaining blocker. After merge: **Actions → Track Publishes → Run workflow** and confirm green.

## What was wrong

**1. The token expired.** It was valid until 18 Feb 2026. Admin API keys are JWTs with roughly a year's life, so this needs rotating rather than debugging. `.github/admin-token.md` is the new runbook: browser login at `api.aem.live/auth/adobe`, copy the `auth_token` cookie, `POST` it to the config API to mint a long-lived key, verify the key against the exact call this workflow makes, store it. Every error message in the workflow now links there.

**2. Wrong API.** The log request still went to `admin.hlx.page/log/{org}/{site}/{ref}`. The Helix 6 API at `api.aem.live` replaces it and drops the `{ref}` segment:

```
https://api.aem.live/{org}/sites/{site}/log?from=...
```

**3. Wrong site.** It asked for the log of `adobe/helix-website`. That alias serves stale pre-DA content — `adobe/aem-website` is what serves www.aem.live, and so is where publishes actually happen. Even with a valid token, the old URL would have reported nothing. Both org and site are now workflow-level `env` vars.

## Also fixed

The expiry pre-check quoted none of its variables and, given anything that was not a JWT, died on a bare `integer expression expected` under `bash -e`. It now checks for an empty secret and a missing `exp` claim explicitly, fails with a message that says what to do, and writes to the step summary as well as emitting an annotation. Verified against five token shapes: valid, expiring within a week, expired, non-JWT, and empty.

## Note for #880

#880 adds a workflow that publishes through this same secret, so it stays blocked until the rotation happens too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
