### PR TITLE
Add autoplay-muted variant to embed block for YouTube videos

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -30,11 +30,12 @@ const gist = (element) => {
   });
 };
 
-const youtube = (element) => {
+const youtube = (element, autoplay) => {
   const url = new URL(element.href);
-  const vid = url.searchParams.get('v');
+  const vid = url.searchParams.get('v') || url.pathname.slice(1);
+  const params = autoplay ? '?autoplay=1&mute=1' : '';
   const html = `<div class="youtube-wrapper">
-          <iframe src="https://www.youtube.com/embed/${vid}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" title="Content from Youtube" loading="lazy"></iframe>
+          <iframe src="https://www.youtube.com/embed/${vid}${params}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" title="Content from Youtube" loading="lazy"></iframe>
       </div>`;
   element.parentElement.insertAdjacentHTML('afterend', html);
   element.parentElement.remove();
@@ -68,9 +69,10 @@ const initObserver = (callback) => new IntersectionObserver((entries) => {
 export default function decorate(block) {
   const a = block.querySelector('a');
   const { hostname } = new URL(a.href);
+  const autoplay = block.classList.contains('autoplay');
   if (hostname.includes('youtu')) {
     initObserver(() => {
-      youtube(a);
+      youtube(a, autoplay);
     }).observe(a);
   } else if (hostname.includes('gist')) {
     initObserver(() => {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -638,7 +638,7 @@ function buildEmbeds(main) {
     ...main.querySelectorAll(
       'a[href^="https://www.youtube.com"], a[href^="https://gist.github.com"]',
     ),
-  ].filter((embed) => !embed.closest('.event-list'));
+  ].filter((embed) => !embed.closest('.event-list') && !embed.closest('.embed'));
   embeds.forEach((embed) => {
     embed.replaceWith(buildBlock('embed', embed.outerHTML));
   });


### PR DESCRIPTION
## Summary
- Adds an `autoplay` variant to the `embed` block: YouTube iframes get `autoplay=1&mute=1` appended so video plays muted on load, with native YouTube controls to unmute.
- Supports `youtu.be/ID` short links (previously only `youtube.com/watch?v=ID` worked).
- Fixes a crash in `buildEmbeds()` (`scripts/scripts.js`) where a YouTube link already inside a manually-authored `.embed` block got wrapped a second time, causing `NoModificationAllowedError` when the two decoration passes raced on the same detached anchor.

Closes #1100

Preview: https://embed-youtube-autoplay--helix-website--adobe.aem.page/developers-live

## Test plan
- [ ] Author an `Embed (autoplay)` block with a `youtube.com/watch?v=...` link — verify it autoplays muted with no console errors
- [ ] Author the same with a `youtu.be/...` link — verify same behavior
- [ ] Author a plain `Embed` block (no autoplay) — verify existing click-to-play behavior is unchanged
- [ ] Confirm a bare YouTube link in body copy still auto-blocks into an embed as before