### PR TITLE
Add play indicator to event-list YouTube thumbnails

### DIFF
--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -83,6 +83,42 @@
   border-radius: 10px;
 }
 
+.event-list .event-list-play-link {
+  position: relative;
+  display: block;
+}
+
+.event-list .event-list-play-link::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: rgb(0 0 0 / 60%);
+  transition: background 0.2s;
+}
+
+.event-list .event-list-play-link::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-46%, -50%);
+  z-index: 1;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 9px 0 9px 16px;
+  border-color: transparent transparent transparent white;
+}
+
+.event-list .event-list-play-link:hover::after {
+  background: rgb(0 0 0 / 80%);
+}
+
 @media (width < 900px) {
   .event-list > .event-list-item {
     grid-template-columns: 1fr;

--- a/blocks/event-list/event-list.js
+++ b/blocks/event-list/event-list.js
@@ -4,9 +4,9 @@ import { createTag } from '../../scripts/scripts.js';
  * Event List — Collection block for community upcoming events.
  *
  * | Event List |
- * | **Upcoming Events** | |
- * | **Title** ¶ Description ¶ **[Date](youtube-url)** on *Show* | https://youtube.com/watch?v=... |
- * | **Title 2** ¶ Description ¶ **Date** on *Show* | |
+ * | ## Upcoming Events | |
+ * | ### Title ¶ Description ¶ **[Date](youtube-url)** on *Show* | https://youtube.com/watch?v=... |
+ * | ### Title 2 ¶ Description ¶ **Date** on *Show* | |
  *
  * Right column: YouTube URL → poster thumbnail + link; empty → default placeholder (no link).
  */
@@ -45,6 +45,8 @@ function buildMedia(cell) {
         href: youtubeUrl,
         target: '_blank',
         rel: 'noopener noreferrer',
+        class: 'event-list-play-link',
+        'aria-label': 'Play video',
       });
       link.append(createTag('img', {
         src: `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`,


### PR DESCRIPTION
## Summary
- Adds a play-button overlay (visible at rest, not just on hover) and `aria-label="Play video"` to the `event-list` block's YouTube thumbnail link.
- Corrects the block's doc comment to describe the actual `h2`/`h3` authoring pattern the code checks for, instead of the bold-text pattern it previously (incorrectly) documented.

Closes #1103

Preview: https://event-list-play-indicator--helix-website--adobe.aem.page/developers-live

## Test plan
- [ ] Author an `Event List` block with a `### Heading 2` section title and `### Title` item title per the corrected doc comment
- [ ] Add a YouTube link (either `youtube.com/watch?v=` or `youtu.be/`) in the media column — verify the play-button overlay renders on the thumbnail
- [ ] Verify an item with a picture (no YouTube link) still renders that picture with no play overlay
- [ ] Verify an item with neither a YouTube link nor a picture still falls back to the default placeholder image