### PR TITLE
Reduce event-list block padding to match paragraph spacing

### DIFF
--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -1,6 +1,6 @@
 /* Community upcoming events — fixed two-column rows */
 .event-list {
-  padding: var(--spacing-xl) var(--spacing-m);
+  padding: var(--spacing-s) var(--spacing-m);
   box-sizing: border-box;
 }
 

--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -41,7 +41,7 @@
 }
 
 .event-list .event-list-content p {
-  font-size: var(--type-body-s-size);
+  font-size: var(--type-body-m-size);
   line-height: 1.6;
   color: var(--color-gray-700);
   margin-bottom: 12px;

--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -47,27 +47,27 @@
   margin-bottom: 12px;
 }
 
-.event-list .event-list-content p:last-child {
+.event-list .event-list-content p:not(:first-of-type) {
   font-size: var(--type-body-xs-size);
   color: var(--color-gray-600);
   margin-bottom: 0;
 }
 
-.event-list .event-list-content p:last-child strong {
+.event-list .event-list-content p:not(:first-of-type) strong {
   font-weight: 600;
   color: var(--color-accent-blue);
 }
 
-.event-list .event-list-content p:last-child strong a:any-link {
+.event-list .event-list-content p:not(:first-of-type) strong a:any-link {
   color: inherit;
   text-decoration: none;
 }
 
-.event-list .event-list-content p:last-child strong a:any-link:hover {
+.event-list .event-list-content p:not(:first-of-type) strong a:any-link:hover {
   text-decoration: underline;
 }
 
-.event-list .event-list-content p:last-child em {
+.event-list .event-list-content p:not(:first-of-type) em {
   font-style: italic;
 }
 


### PR DESCRIPTION
## Summary
- Reduces `.event-list`'s vertical padding from `var(--spacing-xl)` (56px) to `var(--spacing-s)` (24px), matching normal paragraph-to-heading spacing used elsewhere on the site.
- The larger padding made sense for a standalone-section block, but this block is commonly authored inline between regular paragraphs in the same section, where the extra 56px reads as an oversized, unintentional-looking gap.
- Bumps `.event-list-content p` font-size from `--type-body-s-size` (16px) to `--type-body-m-size` (18px) — it read noticeably smaller than the page's default paragraph size (20px).
- Fixes a selector bug where `p:last-child` (meant to style a trailing "Date on Show" metadata line) also matched the *only* paragraph in single-paragraph items — since that `<p>` is last among all siblings including the `<h3>` — silently forcing those descriptions down to the smaller 14px metadata size instead of the 18px just added. Switched to `p:not(:first-of-type)` so it only applies to a genuine second-or-later paragraph.

Closes #1105

Preview: https://event-list-reduce-padding--aem-website--adobe.aem.page/developers-live

## Test plan
- [ ] Author an `Event List` block inline between paragraphs (no section break) — verify the spacing above/below the block now matches normal paragraph spacing
- [ ] Confirm the block's internal item spacing (borders, gaps between items) is unaffected
- [ ] Verify an item with a single description paragraph renders that paragraph at 18px (not 14px)
- [ ] Verify an item with a description + a trailing "Date on Show" line renders the description at 18px and the metadata line at 14px