### PR TITLE
Add compact card variant to event-list block

### DIFF
--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -129,3 +129,110 @@
     max-width: 400px;
   }
 }
+
+.event-list.compact .event-list-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.event-list.compact .event-list-card {
+  display: flex;
+  flex-direction: column;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--color-gray-200);
+  background: light-dark(var(--color-white), var(--color-gray-900));
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  color: inherit;
+  text-decoration: none;
+}
+
+.event-list.compact a.event-list-card:hover {
+  border-color: var(--color-brand-purple, var(--color-accent-purple));
+  box-shadow: 0 4px 16px rgb(138 141 243 / 10%);
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.event-list.compact .event-list-card-thumb {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: var(--color-gray-100);
+}
+
+.event-list.compact .event-list-card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.event-list.compact a .event-list-card-thumb::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgb(0 0 0 / 60%);
+  transition: background 0.2s;
+}
+
+.event-list.compact a .event-list-card-thumb::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-42%, -50%);
+  z-index: 1;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 7px 0 7px 13px;
+  border-color: transparent transparent transparent white;
+}
+
+.event-list.compact a.event-list-card:hover .event-list-card-thumb::after {
+  background: rgb(0 0 0 / 80%);
+}
+
+.event-list.compact .event-list-card-info {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.event-list.compact .event-list-card-info strong {
+  font-size: var(--type-body-xs-size);
+  font-weight: 600;
+  color: light-dark(var(--color-black), var(--color-gray-100));
+  line-height: 1.3;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.event-list.compact .event-list-card-date {
+  font-size: var(--type-body-xxs-size);
+  color: var(--color-gray-600);
+  font-weight: 400;
+}
+
+@media screen and (width < 900px) {
+  .event-list.compact .event-list-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media screen and (width < 400px) {
+  .event-list.compact .event-list-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/blocks/event-list/event-list.js
+++ b/blocks/event-list/event-list.js
@@ -9,6 +9,14 @@ import { createTag } from '../../scripts/scripts.js';
  * | ### Title 2 ¶ Description ¶ **Date** on *Show* | |
  *
  * Right column: YouTube URL → poster thumbnail + link; empty → default placeholder (no link).
+ *
+ * `Event List (compact)` variant: same content model, rendered as a tight card
+ * grid (thumbnail, title, date only — description text is not shown).
+ * | ### Title ¶ Date | https://youtube.com/watch?v=... |
+ * | ### Title 2 ¶ Date | |
+ *
+ * Right column empty → placeholder thumbnail, non-clickable card (for
+ * sessions that haven't happened yet).
  */
 
 const DEFAULT_PLACEHOLDER = '/blocks/event-list/thursday-frequency-default.png';
@@ -77,10 +85,52 @@ function buildMedia(cell) {
   return media;
 }
 
+function getThumbnailSrc(cell) {
+  const youtubeUrl = getYouTubeUrl(cell);
+  if (youtubeUrl) {
+    const videoId = getYouTubeId(youtubeUrl);
+    if (videoId) return `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`;
+  }
+
+  const img = cell?.querySelector('img');
+  if (img) return img.src;
+
+  return DEFAULT_PLACEHOLDER;
+}
+
+function buildCompactCard(cells) {
+  const title = cells[0].querySelector('h3');
+  const date = cells[0].querySelector('p');
+  const href = getYouTubeUrl(cells[1]);
+
+  const card = createTag(href ? 'a' : 'div', {
+    class: 'event-list-card',
+    ...(href ? { href, target: '_blank', rel: 'noopener noreferrer' } : {}),
+  });
+
+  const thumb = createTag('div', { class: 'event-list-card-thumb' });
+  thumb.append(createTag('img', {
+    src: getThumbnailSrc(cells[1]),
+    alt: '',
+    loading: 'lazy',
+  }));
+  card.append(thumb);
+
+  const info = createTag('div', { class: 'event-list-card-info' });
+  if (title) info.append(createTag('strong', {}, title.textContent));
+  if (date) info.append(createTag('span', { class: 'event-list-card-date' }, date.textContent));
+  card.append(info);
+
+  return card;
+}
+
 export default function decorate(block) {
+  const isCompact = block.classList.contains('compact');
   const rows = [...block.querySelectorAll(':scope > div')];
 
   block.textContent = '';
+
+  const grid = isCompact ? createTag('div', { class: 'event-list-grid' }) : null;
 
   rows.forEach((row) => {
     const cells = [...row.children].filter((cell) => cell.tagName === 'DIV');
@@ -96,10 +146,17 @@ export default function decorate(block) {
 
     if (cells.length < 2 || !cells[0].querySelector('h3')) return;
 
+    if (isCompact) {
+      grid.append(buildCompactCard(cells));
+      return;
+    }
+
     const item = createTag('div', { class: 'event-list-item' });
     const content = createTag('div', { class: 'event-list-content' });
     content.innerHTML = cells[0].innerHTML;
     item.append(content, buildMedia(cells[1]));
     block.append(item);
   });
+
+  if (isCompact) block.append(grid);
 }


### PR DESCRIPTION
## Summary
- Adds an `Event List (compact)` variant (`class="event-list compact"`) that keeps the same authoring model as the default `event-list` block but renders as a tight grid of thumbnail-top cards (title + date only, description dropped) instead of full-width rows.
- Visual style matches the `feed` block's compact card view (thumbnail, title, date), minus its filter tabs, since this is scoped to a single series.
- Items with no YouTube link render as a non-clickable card with a placeholder thumbnail — for sessions that haven't happened yet.
- Title detection still requires an actual `<h3>` (not bold text) to classify the row as a content item, same as the default variant.

Closes #1108

Preview: https://event-list-compact-variant--aem-website--adobe.aem.page/developers-live

## Test plan
- [ ] Author an `Event List (compact)` block with a `## Heading`, then several `### Title` items with a date paragraph and a YouTube link — verify a card grid renders with play-icon thumbnails
- [ ] Add an item with no link — verify it renders as a non-clickable card with the placeholder thumbnail
- [ ] Confirm the default (non-compact) `event-list` variant is unaffected
- [ ] Check responsive grid columns (4 desktop / 2 tablet / 1 mobile)