### PR TITLE
fix(event-list): unblock stylelint on mutually exclusive variant selectors

### DIFF
--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -206,6 +206,11 @@
   gap: 3px;
 }
 
+/* Mutually exclusive with the default variant, so there is no cascade to order:
+   decorate() branches on isCompact, and .event-list-card-info is only built by
+   buildCompactCard() while .event-list-content is only built by the non-compact
+   branch. No <strong> can match both this and the .event-list-content rule above. */
+/* stylelint-disable-next-line no-descending-specificity */
 .event-list.compact .event-list-card-info strong {
   font-size: var(--type-body-xs-size);
   font-weight: 600;


### PR DESCRIPTION
## Summary

`main` has been failing `build` since #1109 was merged on 5 Sep. Every open PR in the repo inherits the failure through its merge commit, so nothing can go green until this is cleared.

```
blocks/event-list/event-list.css
  209:1  ✖  Expected selector ".event-list.compact .event-list-card-info strong" to come
            before selector ".event-list .event-list-content p:not(:first-of-type) strong",
            at line 56  no-descending-specificity
```

`main` itself runs no `build` check on push, which is why a red merge went unnoticed for three days.

## Why a disable comment rather than a reorder

The two selectors can never match the same element, so there is no cascade to order and nothing to fix by moving code.

`decorate()` branches on `isCompact` and the two shapes are built in different arms:

- `.event-list-card-info` is created only in `buildCompactCard()`, reached only when `isCompact`
- `.event-list-content` is created only in the `else` arm, which returns before any card is built

So a `<strong>` inside `.event-list-card-info` is only ever produced for `.event-list.compact`, and a `<strong>` inside `.event-list-content p` only for the non-compact block. No element is in both subtrees.

Specificity is also close enough that order would be irrelevant even if they did overlap: `.event-list.compact .event-list-card-info strong` is (0,3,1) against `.event-list .event-list-content p:not(:first-of-type) strong` at (0,3,2), so the content rule already wins on specificity regardless of source order.

Reordering would mean hoisting a variant rule up into the base-styles section purely to satisfy a linter, which makes the file harder to read and changes nothing at runtime. The scoped disable matches the convention already used five lines further down for `value-no-vendor-prefix`.

## Verification

No behavioural change: the diff adds only comments. Zero declarations, selectors or property values are touched — 5 added lines, 0 removed.

The rule was then executed against both versions of the file, driving stylelint's own `no-descending-specificity` rule module over a postcss AST with stylelint's own `assignDisabledRanges` for comment handling:

```
main-version.css: 1 problem(s)
  209:1  Expected selector ".event-list.compact .event-list-card-info strong" to come before
         selector ".event-list .event-list-content p:not(:first-of-type) strong", at line 56
event-list.css (this PR): 0 problem(s)
```

The first line reproduces the CI diagnostic byte-for-byte, including the line and column, which is what makes the second line meaningful rather than merely optimistic.

The stylelint *binary* does not run in this environment — `node:module` is unavailable and six packages in its dependency graph require it (`stylelint`, `import-meta-resolve`, `meow`, `resolve-from`, `require-from-string`, `css-tree`) — so the check above bypasses the CLI and config layers and runs the rule directly. It therefore validates this one rule, not the whole `lint:css` run. That this is the only remaining error rests on the CI log for `improve-publish-notifications` @ `1d87fb47`, which reports exactly `✖ 1 problem (1 error, 0 warnings)`. CI on this PR is the authoritative check.