### PR TITLE
feat: add "New" badge to event-list compact cards

### DIFF
--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -206,8 +206,8 @@
   z-index: 2;
   padding: 2px 8px;
   border-radius: 4px;
-  background: var(--color-accent-blue);
-  color: var(--color-white);
+  background: var(--color-white);
+  color: var(--color-black);
   font-size: var(--type-body-xxs-size);
   font-weight: 600;
   line-height: 1.4;

--- a/blocks/event-list/event-list.css
+++ b/blocks/event-list/event-list.css
@@ -199,6 +199,20 @@
   background: rgb(0 0 0 / 80%);
 }
 
+.event-list.compact .event-list-card-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--color-accent-blue);
+  color: var(--color-white);
+  font-size: var(--type-body-xxs-size);
+  font-weight: 600;
+  line-height: 1.4;
+}
+
 .event-list.compact .event-list-card-info {
   padding: 10px 12px;
   display: flex;

--- a/blocks/event-list/event-list.js
+++ b/blocks/event-list/event-list.js
@@ -98,6 +98,25 @@ function getThumbnailSrc(cell) {
   return DEFAULT_PLACEHOLDER;
 }
 
+const NEW_BADGE_WINDOW_DAYS = 5;
+
+function parseEventDate(text) {
+  const match = text?.match(/(\d{1,2})\s+([A-Za-z]{3,})\s+(\d{4})/);
+  if (!match) return null;
+  const [, day, month, year] = match;
+  const date = new Date(`${month} ${day}, ${year}`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isWithinNewBadgeWindow(date) {
+  if (!date) return false;
+  const start = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const end = new Date(start);
+  end.setDate(end.getDate() + NEW_BADGE_WINDOW_DAYS);
+  const now = new Date();
+  return now >= start && now < end;
+}
+
 function buildCompactCard(cells) {
   const title = cells[0].querySelector('h3');
   const date = cells[0].querySelector('p');
@@ -114,6 +133,9 @@ function buildCompactCard(cells) {
     alt: '',
     loading: 'lazy',
   }));
+  if (isWithinNewBadgeWindow(parseEventDate(date?.textContent))) {
+    thumb.append(createTag('span', { class: 'event-list-card-badge' }, 'New'));
+  }
   card.append(thumb);
 
   const info = createTag('div', { class: 'event-list-card-info' });


### PR DESCRIPTION
## Summary
- Adds a "New" badge to `event-list` compact cards when the recording's date is within 5 days of today, so recently published sessions stand out without needing an authored flag.
- Badge is placed top-right of the thumbnail (top-left is already used for the play icon overlay).
- "Coming Soon" (future-dated) entries do not show the badge.

Closes adobe/helix-website#1111

## Preview
https://event-list-new-badge--aem-website--adobe.aem.page/developers-live

## Test plan
- [ ] Confirm badge shows on cards dated within the last 5 days (as of review date)
- [ ] Confirm badge does not show on older recordings
- [ ] Confirm badge does not show on "Coming Soon" entries
- [ ] Check responsive layout (2-col and 1-col breakpoints) doesn't clip the badge