### PR TITLE
fix: collapse same-path duplicate publish announcements within 120s

### DIFF
--- a/.github/workflows/track-publishes.yml
+++ b/.github/workflows/track-publishes.yml
@@ -220,8 +220,8 @@ jobs:
           # concurrency group: a run cancelled mid-dispatch does not advance the watermark,
           # so its successor re-reads the same entries.
           #
-          # The collapse step groups by path, then within each group keeps only entries
-          # whose timestamps are more than COLLAPSE_SECONDS apart. This handles the
+          # The collapse step groups by path, user and status, then within each group keeps
+          # only entries whose timestamps are more than COLLAPSE_SECONDS apart. This handles the
           # admin log recording a single logical publish multiple times seconds apart
           # (see the COLLAPSE_SECONDS comment above). The pre-collapse result is written
           # to all.ndjson so that dropped entries remain visible in the run log.
@@ -239,11 +239,13 @@ jobs:
             | sort_by(.timestamp)
             | .[]' body.json > all.ndjson
 
-          # Collapse a burst of the same path into its newest entry. This reads all.ndjson so
-          # the extraction filter above stays the single source of truth for both files: there
-          # is no second copy to drift out of step with it.
+          # Collapse a burst of identical entries into the newest one. The key is path + user
+          # + status, not path alone: two people publishing the same path inside the window are
+          # two real announcements, and a success followed by a failure must not be masked.
+          # Reads all.ndjson so the extraction filter above stays the single source of truth for
+          # both files, with no second copy to drift out of step with it.
           jq -c -s --argjson collapse_ms "$(( COLLAPSE_SECONDS * 1000 ))" '
-            group_by(.path)
+            group_by([ .path, .user, .status ])
             | map(
                 sort_by(.timestamp)
                 | reverse
@@ -262,7 +264,7 @@ jobs:
           echo "Publishes to announce: $COUNT"
           if [[ "$ALL_COUNT" -ne "$COUNT" ]]; then
             COLLAPSED=$((ALL_COUNT - COUNT))
-            echo "Collapsed $COLLAPSED same-path duplicate(s) within ${COLLAPSE_SECONDS}s"
+            echo "Collapsed $COLLAPSED duplicate entr(y|ies) with the same path, user and status within ${COLLAPSE_SECONDS}s"
             echo "Pre-collapse entries:"
             cat all.ndjson
           fi

--- a/.github/workflows/track-publishes.yml
+++ b/.github/workflows/track-publishes.yml
@@ -38,6 +38,13 @@ env:
   AEM_SITE: "aem-website"
   OVERLAP_SECONDS: "60" # re-read this much before the watermark so a boundary publish is never lost
   WIDE_WINDOW_HOURS: "6" # warn above this, rather than silently narrowing the window
+  # One logical publish can hit the admin log more than once seconds apart. Observed:
+  # /docs/global.json appeared twice in run 34345742857 (timestamps 1788952659491 and
+  # 1788952676113, 16.6s apart, same user and status 200). unique_by([ .path, .timestamp ])
+  # cannot collapse them because the timestamps differ, so the channel got two identical
+  # messages. A 120s window collapses a burst while preserving a deliberate re-publish
+  # minutes later. The newest entry wins so the announcement reflects the final state.
+  COLLAPSE_SECONDS: "120"
 
 # One job, not three. The three former jobs each paid their own queue wait, which under
 # backlog pulled them minutes to hours apart: run 34221704920 resolved its watermark at
@@ -212,6 +219,12 @@ jobs:
           # collapse duplicates. unique_by is a second line of defence behind the
           # concurrency group: a run cancelled mid-dispatch does not advance the watermark,
           # so its successor re-reads the same entries.
+          #
+          # The collapse step groups by path, then within each group keeps only entries
+          # whose timestamps are more than COLLAPSE_SECONDS apart. This handles the
+          # admin log recording a single logical publish multiple times seconds apart
+          # (see the COLLAPSE_SECONDS comment above). The pre-collapse result is written
+          # to all.ndjson so that dropped entries remain visible in the run log.
           jq -c --arg route "$ROUTE_FILTER" --argjson floor "$FROM_MS" '
             [ .entries[]?
               | select(.route == $route)
@@ -224,11 +237,43 @@ jobs:
               | { path: ., user: $entry.user, timestamp: $entry.timestamp, status: $entry.status } ]
             | unique_by([ .path, .timestamp ])
             | sort_by(.timestamp)
+            | .[]' body.json > all.ndjson
+
+          jq -c --arg route "$ROUTE_FILTER" --argjson floor "$FROM_MS" \
+            --argjson collapse_ms "$(( COLLAPSE_SECONDS * 1000 ))" '
+            [ .entries[]?
+              | select(.route == $route)
+              | select((.timestamp // 0) >= $floor)
+              | { user: (.user // "unknown"), timestamp: .timestamp, status: .status,
+                  paths: ([ .path ] + (.paths // [])) }
+              | . as $entry
+              | $entry.paths[]
+              | select(. != null and . != "")
+              | { path: ., user: $entry.user, timestamp: $entry.timestamp, status: $entry.status } ]
+            | unique_by([ .path, .timestamp ])
+            | group_by(.path)
+            | map(
+                sort_by(.timestamp)
+                | reverse
+                | reduce .[] as $e ([];
+                    if (length == 0) or ((.[-1].timestamp - $e.timestamp) > $collapse_ms)
+                    then . + [$e]
+                    else . end)
+              )
+            | flatten
+            | sort_by(.timestamp)
             | .[]' body.json > publishes.ndjson
 
+          ALL_COUNT=$(wc -l < all.ndjson | tr -d ' ')
           COUNT=$(wc -l < publishes.ndjson | tr -d ' ')
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Publishes to announce: $COUNT"
+          if [[ "$ALL_COUNT" -ne "$COUNT" ]]; then
+            COLLAPSED=$((ALL_COUNT - COUNT))
+            echo "Collapsed $COLLAPSED same-path duplicate(s) within ${COLLAPSE_SECONDS}s"
+            echo "Pre-collapse entries:"
+            cat all.ndjson
+          fi
           cat publishes.ndjson
 
       - name: Announce publishes

--- a/.github/workflows/track-publishes.yml
+++ b/.github/workflows/track-publishes.yml
@@ -239,19 +239,11 @@ jobs:
             | sort_by(.timestamp)
             | .[]' body.json > all.ndjson
 
-          jq -c --arg route "$ROUTE_FILTER" --argjson floor "$FROM_MS" \
-            --argjson collapse_ms "$(( COLLAPSE_SECONDS * 1000 ))" '
-            [ .entries[]?
-              | select(.route == $route)
-              | select((.timestamp // 0) >= $floor)
-              | { user: (.user // "unknown"), timestamp: .timestamp, status: .status,
-                  paths: ([ .path ] + (.paths // [])) }
-              | . as $entry
-              | $entry.paths[]
-              | select(. != null and . != "")
-              | { path: ., user: $entry.user, timestamp: $entry.timestamp, status: $entry.status } ]
-            | unique_by([ .path, .timestamp ])
-            | group_by(.path)
+          # Collapse a burst of the same path into its newest entry. This reads all.ndjson so
+          # the extraction filter above stays the single source of truth for both files: there
+          # is no second copy to drift out of step with it.
+          jq -c -s --argjson collapse_ms "$(( COLLAPSE_SECONDS * 1000 ))" '
+            group_by(.path)
             | map(
                 sort_by(.timestamp)
                 | reverse
@@ -262,7 +254,7 @@ jobs:
               )
             | flatten
             | sort_by(.timestamp)
-            | .[]' body.json > publishes.ndjson
+            | .[]' all.ndjson > publishes.ndjson
 
           ALL_COUNT=$(wc -l < all.ndjson | tr -d ' ')
           COUNT=$(wc -l < publishes.ndjson | tr -d ' ')


### PR DESCRIPTION
## Problem

The Slack channel received duplicate announcements for `/docs/global.json`.

Run `34344792691` (created 11:17:47Z) logged `Publishes to announce: 0`. Run `34345742857`
(created 11:28:32Z) logged `Publishes to announce: 2` and dispatched `/docs/global.json`
twice. Its `publishes.ndjson` held exactly:

```
{"path":"/docs/global.json","user":"rofe@adobe.com","timestamp":1788952659491,"status":200}
{"path":"/docs/global.json","user":"rofe@adobe.com","timestamp":1788952676113,"status":200}
```

Two entries, same path, same user, both status 200, timestamps 16.6 seconds apart
(11:17:39.491 and 11:17:56.113). The existing guard `unique_by([ .path, .timestamp ])`
cannot collapse them because the timestamps differ. The upstream admin log genuinely holds
two entries for one logical publish, and the workflow faithfully announces both.

### What this is NOT

- **Not the backlog-drain duplicate.** The `concurrency: cancel-in-progress` block already
  handles that, and it worked correctly here: this was a single run dispatching twice.
- **Not the `OVERLAP_SECONDS` re-read.** All 12 runs between 10:24Z and 12:31Z were checked:
  the only entries announced in that whole span were the two above, and no
  `(path, timestamp)` pair was announced by two different runs.

## Fix

Add `COLLAPSE_SECONDS: "120"`. After the existing `unique_by`, group entries by
**`[ .path, .user, .status ]`** and within each group keep only entries more than 120 seconds
apart, keeping the newest of each burst.

The key is deliberately not `.path` alone. Two people publishing the same path inside the
window are two real announcements, not a duplicate, and `log-publish.yml` reads `user` to name
the publisher, so collapsing on path alone would silently drop one of them. `status` is in the
key for the same reason: a success followed by a failure on the same path must not be masked.
The observed duplicate shared path, user and status, so the narrower key still collapses the
case this PR exists to fix. Thanks to the Codex review for catching that.

A deliberate re-publish minutes later still announces. The newest entry wins, so the
announcement reflects the final state.

The collapse reads `all.ndjson` rather than re-running the extraction filter, so the route
filter, window floor and `paths[]` flattening exist in exactly one place and the pre-collapse
log cannot disagree with the dispatched set. When anything is collapsed, the count and the raw
pre-collapse entries are logged, so a dropped announcement is visible in the run log rather
than silently discarded.

## Verification

Both `jq` invocations were extracted verbatim from the workflow and run against a synthetic
`body.json`: 6 entries in, 5 dispatched. `global.json` collapsed to the newest entry; the same
path published by two different users 30s apart kept BOTH; a 200 followed by a 502 on one path
kept BOTH. An empty log exits 0 under `set -euo pipefail`. The collapse key was unit-tested
against the real entries plus 8 edge cases. The file parses as YAML with all 9 env vars, the
`concurrency` block and all 4 steps intact.

`aem-psi-check` fails here because a workflow-only branch has no preview content for Lighthouse
to load. It is not a required check and it fails the same way on #1107.

## Changed file

`.github/workflows/track-publishes.yml` only. No page content changes.

URL for testing:

- https://fix-collapse-duplicate-publish-announcements--helix-website--adobe.aem.page/
